### PR TITLE
Optional watch-namespaces for controller manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,19 @@ It means the FluentBit Operator works properly if you see the above messages, yo
 kubectl delete -f https://raw.githubusercontent.com/kubesphere/fluentbit-operator/master/manifests/quick-start/quick-start.yaml
 ```
 
+### Configure Custom Watch Namespaces
+
+When starting the operator, you can pass an optional set of namespaces to watch for resources in with the `--watch-namespaces` flag. It takes a comma-separated list of namespaces to watch:
+
+```
+...
+      spec:
+        containers:
+          image: kubesphere/fluentbit-operator
+        - args:
+          - --watch-namespaces=namespace1,namespace2
+```
+
 ### Collect Kubernetes logs
 
 This guide provisions a logging pipeline including the Fluent Bit DaemonSet and its log input/filter/output configurations to collect Kubernetes logs including container logs and kubelet logs.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -88,12 +88,12 @@ rules:
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
-  - clusterrolebindings
+  - rolebindings
   verbs:
   - create
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
-  - clusterroles
+  - roles
   verbs:
   - create

--- a/controllers/fluentbit_controller.go
+++ b/controllers/fluentbit_controller.go
@@ -44,8 +44,8 @@ type FluentBitReconciler struct {
 // +kubebuilder:rbac:groups=logging.kubesphere.io,resources=fluentbits;fluentbitconfigs;inputs;filters;outputs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=create
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=create
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=create
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=create
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get
 
 func (r *FluentBitReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {

--- a/manifests/setup/fluentbit-operator-clusterRole.yaml
+++ b/manifests/setup/fluentbit-operator-clusterRole.yaml
@@ -89,12 +89,12 @@ rules:
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:
-      - clusterrolebindings
+      - rolebindings
     verbs:
       - create
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:
-      - clusterroles
+      - roles
     verbs:
       - create

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -4289,13 +4289,13 @@ rules:
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
-  - clusterrolebindings
+  - rolebindings
   verbs:
   - create
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
-  - clusterroles
+  - roles
   verbs:
   - create
 ---

--- a/pkg/operator/daemonset.go
+++ b/pkg/operator/daemonset.go
@@ -10,10 +10,11 @@ import (
 	"kubesphere.io/fluentbit-operator/api/fluentbitoperator/v1alpha2"
 )
 
-func MakeRBACObjects(fbName, fbNamespace string) (rbacv1.ClusterRole, corev1.ServiceAccount, rbacv1.ClusterRoleBinding) {
-	cr := rbacv1.ClusterRole{
+func MakeRBACObjects(fbName, fbNamespace string) (rbacv1.Role, corev1.ServiceAccount, rbacv1.RoleBinding) {
+	r := rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "kubesphere:fluent-bit",
+			Name:      "kubesphere:fluent-bit",
+			Namespace: fbNamespace,
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
@@ -31,9 +32,10 @@ func MakeRBACObjects(fbName, fbNamespace string) (rbacv1.ClusterRole, corev1.Ser
 		},
 	}
 
-	crb := rbacv1.ClusterRoleBinding{
+	rb := rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "kubesphere:fluent-bit",
+			Name:      "kubesphere:fluent-bit",
+			Namespace: fbNamespace,
 		},
 		Subjects: []rbacv1.Subject{
 			{
@@ -44,12 +46,12 @@ func MakeRBACObjects(fbName, fbNamespace string) (rbacv1.ClusterRole, corev1.Ser
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: rbacv1.GroupName,
-			Kind:     "ClusterRole",
+			Kind:     "Role",
 			Name:     "kubesphere:fluent-bit",
 		},
 	}
 
-	return cr, sa, crb
+	return r, sa, rb
 }
 
 func MakeDaemonSet(fb v1alpha2.FluentBit, logPath string) appsv1.DaemonSet {


### PR DESCRIPTION
### Description

#### What does this pull request accomplish

* Adds `--watch-namespaces` command line argument to operator; if provided it only watches for resources in the specified namespaces
* Updates fluentbit RBAC from cluster scoped to namespace scoped