### PR TITLE
Add supports for Amazon ElasticSearch Service and Elastic's Elasticse…

### DIFF
--- a/api/fluentbitoperator/v1alpha2/plugins/tls_types.go
+++ b/api/fluentbitoperator/v1alpha2/plugins/tls_types.go
@@ -30,7 +30,7 @@ type TLS struct {
 
 func (t *TLS) Params(sl SecretLoader) (*KVs, error) {
 	kvs := NewKVs()
-	kvs.Insert("tls", "true")
+	kvs.Insert("tls", "On")
 	if t.Verify != nil {
 		kvs.Insert("tls.verify", fmt.Sprint(*t.Verify))
 	}

--- a/config/crd/bases/logging.kubesphere.io_outputs.yaml
+++ b/config/crd/bases/logging.kubesphere.io_outputs.yaml
@@ -43,6 +43,24 @@ spec:
               es:
                 description: Elasticsearch defines Elasticsearch Output configuration.
                 properties:
+                  awsAuth:
+                    description: Enable AWS Sigv4 Authentication for Amazon ElasticSearch
+                      Service.
+                    type: string
+                  awsExternalID:
+                    description: External ID for the AWS IAM Role specified with aws_role_arn.
+                    type: string
+                  awsRegion:
+                    description: Specify the AWS region for Amazon ElasticSearch Service.
+                    type: string
+                  awsRoleARN:
+                    description: AWS IAM Role to assume to put records to your Amazon
+                      ES cluster.
+                    type: string
+                  awsSTSEndpoint:
+                    description: Specify the custom sts endpoint to be used with STS
+                      API for Amazon ElasticSearch Service.
+                    type: string
                   bufferSize:
                     description: Specify the buffer size used to read the response
                       from the Elasticsearch HTTP service. This option is useful for
@@ -52,6 +70,14 @@ spec:
                       to False, otherwise the value must be according to the Unit
                       Size specification.
                     pattern: ^\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$
+                    type: string
+                  cloudAuth:
+                    description: Specify the credentials to use to connect to Elastic's
+                      Elasticsearch Service running on Elastic Cloud.
+                    type: string
+                  cloudID:
+                    description: If you are using Elastic's Elasticsearch Service
+                      you can specify the cloud_id of the cluster running.
                     type: string
                   currentTimeIndex:
                     description: Use current time for index generation instead of
@@ -121,6 +147,10 @@ spec:
                             type: object
                         type: object
                     type: object
+                  idKey:
+                    description: If set, _id will be the value of the key from incoming
+                      record and Generate_ID option is ignored.
+                    type: string
                   includeTagKey:
                     description: When enabled, it append the Tag name to the record.
                     type: boolean
@@ -153,11 +183,11 @@ spec:
                       indexing HTTP POST URI.
                     type: string
                   pipeline:
-                    description: Newer versions of Elasticsearch allows to setup filters
-                      called pipelines. This option allows to define which pipeline
-                      the database should use. For performance reasons is strongly
-                      suggested to do parsing and filtering on Fluent Bit side, avoid
-                      pipelines.
+                    description: Newer versions of Elasticsearch allows setting up
+                      filters called pipelines. This option allows defining which
+                      pipeline the database should use. For performance reasons is
+                      strongly suggested parsing and filtering on Fluent Bit side,
+                      avoid pipelines.
                     type: string
                   port:
                     description: TCP port of the target Elasticsearch instance
@@ -169,6 +199,11 @@ spec:
                     description: When enabled, replace field name dots with underscore,
                       required by Elasticsearch 2.0-2.3.
                     type: boolean
+                  suppressTypeName:
+                    description: When enabled, mapping types is removed and Type option
+                      is ignored. Types are deprecated in APIs in v7.0. This options
+                      is for v7.0 or later.
+                    type: string
                   tagKey:
                     description: When Include_Tag_Key is enabled, this property defines
                       the key name for the tag.

--- a/manifests/setup/fluentbit-operator-crd.yaml
+++ b/manifests/setup/fluentbit-operator-crd.yaml
@@ -19,14 +19,10 @@ spec:
         description: Filter defines a Filter configuration.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -41,42 +37,33 @@ spec:
                       description: Grep defines Grep Filter configuration.
                       properties:
                         exclude:
-                          description: 'Exclude records which field matches the regular
-                            expression. Value Format: FIELD REGEX'
+                          description: 'Exclude records which field matches the regular expression. Value Format: FIELD REGEX'
                           type: string
                         regex:
-                          description: 'Keep records which field matches the regular
-                            expression. Value Format: FIELD REGEX'
+                          description: 'Keep records which field matches the regular expression. Value Format: FIELD REGEX'
                           type: string
                       type: object
                     kubernetes:
                       description: Kubernetes defines Kubernetes Filter configuration.
                       properties:
                         annotations:
-                          description: Include Kubernetes resource annotations in
-                            the extra metadata.
+                          description: Include Kubernetes resource annotations in the extra metadata.
                           type: boolean
                         bufferSize:
-                          description: Set the buffer size for HTTP client when reading
-                            responses from Kubernetes API server.
+                          description: Set the buffer size for HTTP client when reading responses from Kubernetes API server.
                           pattern: ^\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$
                           type: string
                         dummyMeta:
                           description: If set, use dummy-meta data (for test/dev purposes)
                           type: boolean
                         k8sLoggingExclude:
-                          description: Allow Kubernetes Pods to exclude their logs
-                            from the log processor (read more about it in Kubernetes
-                            Annotations section).
+                          description: Allow Kubernetes Pods to exclude their logs from the log processor (read more about it in Kubernetes Annotations section).
                           type: boolean
                         k8sLoggingParser:
-                          description: Allow Kubernetes Pods to suggest a pre-defined
-                            Parser (read more about it in Kubernetes Annotations section)
+                          description: Allow Kubernetes Pods to suggest a pre-defined Parser (read more about it in Kubernetes Annotations section)
                           type: boolean
                         keepLog:
-                          description: When Keep_Log is disabled, the log field is
-                            removed from the incoming message once it has been successfully
-                            merged (Merge_Log must be enabled as well).
+                          description: When Keep_Log is disabled, the log field is removed from the incoming message once it has been successfully merged (Merge_Log must be enabled as well).
                           type: boolean
                         kubeCAFile:
                           description: CA certificate file
@@ -85,14 +72,10 @@ spec:
                           description: Absolute path to scan for certificate files
                           type: string
                         kubeMetaPreloadCacheDir:
-                          description: If set, Kubernetes meta-data can be cached/pre-loaded
-                            from files in JSON format in this directory, named as
-                            namespace-pod.meta
+                          description: If set, Kubernetes meta-data can be cached/pre-loaded from files in JSON format in this directory, named as namespace-pod.meta
                           type: string
                         kubeTagPrefix:
-                          description: When the source records comes from Tail input
-                            plugin, this option allows to specify what's the prefix
-                            used in Tail configuration.
+                          description: When the source records comes from Tail input plugin, this option allows to specify what's the prefix used in Tail configuration.
                           type: string
                         kubeTokenFile:
                           description: Token file
@@ -101,64 +84,42 @@ spec:
                           description: API Server end-point
                           type: string
                         labels:
-                          description: Include Kubernetes resource labels in the extra
-                            metadata.
+                          description: Include Kubernetes resource labels in the extra metadata.
                           type: boolean
                         mergeLog:
-                          description: When enabled, it checks if the log field content
-                            is a JSON string map, if so, it append the map fields
-                            as part of the log structure.
+                          description: When enabled, it checks if the log field content is a JSON string map, if so, it append the map fields as part of the log structure.
                           type: boolean
                         mergeLogKey:
-                          description: When Merge_Log is enabled, the filter tries
-                            to assume the log field from the incoming message is a
-                            JSON string message and make a structured representation
-                            of it at the same level of the log field in the map. Now
-                            if Merge_Log_Key is set (a string name), all the new structured
-                            fields taken from the original log content are inserted
-                            under the new key.
+                          description: When Merge_Log is enabled, the filter tries to assume the log field from the incoming message is a JSON string message and make a structured representation of it at the same level of the log field in the map. Now if Merge_Log_Key is set (a string name), all the new structured fields taken from the original log content are inserted under the new key.
                           type: string
                         mergeLogTrim:
-                          description: When Merge_Log is enabled, trim (remove possible
-                            \n or \r) field values.
+                          description: When Merge_Log is enabled, trim (remove possible \n or \r) field values.
                           type: boolean
                         mergeParser:
-                          description: Optional parser name to specify how to parse
-                            the data contained in the log key. Recommended use is
-                            for developers or testing only.
+                          description: Optional parser name to specify how to parse the data contained in the log key. Recommended use is for developers or testing only.
                           type: string
                         regexParser:
-                          description: Set an alternative Parser to process record
-                            Tag and extract pod_name, namespace_name, container_name
-                            and docker_id. The parser must be registered in a parsers
-                            file (refer to parser filter-kube-test as an example).
+                          description: Set an alternative Parser to process record Tag and extract pod_name, namespace_name, container_name and docker_id. The parser must be registered in a parsers file (refer to parser filter-kube-test as an example).
                           type: string
                         tlsDebug:
-                          description: Debug level between 0 (nothing) and 4 (every
-                            detail).
+                          description: Debug level between 0 (nothing) and 4 (every detail).
                           format: int32
                           type: integer
                         tlsVerify:
-                          description: When enabled, turns on certificate validation
-                            when connecting to the Kubernetes API server.
+                          description: When enabled, turns on certificate validation when connecting to the Kubernetes API server.
                           type: boolean
                         useJournal:
-                          description: When enabled, the filter reads logs coming
-                            in Journald format.
+                          description: When enabled, the filter reads logs coming in Journald format.
                           type: boolean
                       type: object
                     lua:
                       description: Lua defines Lua Filter configuration.
                       properties:
                         call:
-                          description: Lua function name that will be triggered to
-                            do filtering. It's assumed that the function is declared
-                            inside the Script defined above.
+                          description: Lua function name that will be triggered to do filtering. It's assumed that the function is declared inside the Script defined above.
                           type: string
                         protectedMode:
-                          description: If enabled, Lua script will be executed in
-                            protected mode. It prevents to crash when invalid Lua
-                            script is executed. Default is true.
+                          description: If enabled, Lua script will be executed in protected mode. It prevents to crash when invalid Lua script is executed. Default is true.
                           type: boolean
                         script:
                           description: Path to the Lua script that will be used.
@@ -167,30 +128,19 @@ spec:
                               description: The key to select.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
-                              description: Specify whether the ConfigMap or its key
-                                must be defined
+                              description: Specify whether the ConfigMap or its key must be defined
                               type: boolean
                           required:
                           - key
                           type: object
                         timeAsTable:
-                          description: By default when the Lua script is invoked,
-                            the record timestamp is passed as a Floating number which
-                            might lead to loss precision when the data is converted
-                            back. If you desire timestamp precision enabling this
-                            option will pass the timestamp as a Lua table with keys
-                            sec for seconds since epoch and nsec for nanoseconds.
+                          description: By default when the Lua script is invoked, the record timestamp is passed as a Floating number which might lead to loss precision when the data is converted back. If you desire timestamp precision enabling this option will pass the timestamp as a Lua table with keys sec for seconds since epoch and nsec for nanoseconds.
                           type: boolean
                         typeIntKey:
-                          description: If these keys are matched, the fields are converted
-                            to integer. If more than one key, delimit by space. Note
-                            that starting from Fluent Bit v1.6 integer data types
-                            are preserved and not converted to double as in previous
-                            versions.
+                          description: If these keys are matched, the fields are converted to integer. If more than one key, delimit by space. Note that starting from Fluent Bit v1.6 integer data types are preserved and not converted to double as in previous versions.
                           items:
                             type: string
                           type: array
@@ -202,8 +152,7 @@ spec:
                       description: Modify defines Modify Filter configuration.
                       properties:
                         conditions:
-                          description: All conditions have to be true for the rules
-                            to be applied.
+                          description: All conditions have to be true for the rules to be applied.
                           items:
                             description: The plugin supports the following conditions
                             properties:
@@ -221,38 +170,32 @@ spec:
                               keyValueDoesNotEqual:
                                 additionalProperties:
                                   type: string
-                                description: Is true if KEY exists and its value is
-                                  not VALUE
+                                description: Is true if KEY exists and its value is not VALUE
                                 type: object
                               keyValueDoesNotMatch:
                                 additionalProperties:
                                   type: string
-                                description: Is true if key KEY exists and its value
-                                  does not match VALUE
+                                description: Is true if key KEY exists and its value does not match VALUE
                                 type: object
                               keyValueEquals:
                                 additionalProperties:
                                   type: string
-                                description: Is true if KEY exists and its value is
-                                  VALUE
+                                description: Is true if KEY exists and its value is VALUE
                                 type: object
                               keyValueMatches:
                                 additionalProperties:
                                   type: string
-                                description: Is true if key KEY exists and its value
-                                  matches VALUE
+                                description: Is true if key KEY exists and its value matches VALUE
                                 type: object
                               matchingKeysDoNotHaveMatchingValues:
                                 additionalProperties:
                                   type: string
-                                description: Is true if all keys matching KEY have
-                                  values that do not match VALUE
+                                description: Is true if all keys matching KEY have values that do not match VALUE
                                 type: object
                               matchingKeysHaveMatchingValues:
                                 additionalProperties:
                                   type: string
-                                description: Is true if all keys matching KEY have
-                                  values that match VALUE
+                                description: Is true if all keys matching KEY have values that match VALUE
                                 type: object
                               noKeyMatches:
                                 description: Is true if no key matches regex KEY
@@ -260,64 +203,48 @@ spec:
                             type: object
                           type: array
                         rules:
-                          description: Rules are applied in the order they appear,
-                            with each rule operating on the result of the previous
-                            rule.
+                          description: Rules are applied in the order they appear, with each rule operating on the result of the previous rule.
                           items:
                             description: The plugin supports the following rules
                             properties:
                               add:
                                 additionalProperties:
                                   type: string
-                                description: Add a key/value pair with key KEY and
-                                  value VALUE if KEY does not exist
+                                description: Add a key/value pair with key KEY and value VALUE if KEY does not exist
                                 type: object
                               copy:
                                 additionalProperties:
                                   type: string
-                                description: Copy a key/value pair with key KEY to
-                                  COPIED_KEY if KEY exists AND COPIED_KEY does not
-                                  exist
+                                description: Copy a key/value pair with key KEY to COPIED_KEY if KEY exists AND COPIED_KEY does not exist
                                 type: object
                               hardCopy:
                                 additionalProperties:
                                   type: string
-                                description: Copy a key/value pair with key KEY to
-                                  COPIED_KEY if KEY exists. If COPIED_KEY already
-                                  exists, this field is overwritten
+                                description: Copy a key/value pair with key KEY to COPIED_KEY if KEY exists. If COPIED_KEY already exists, this field is overwritten
                                 type: object
                               hardRename:
                                 additionalProperties:
                                   type: string
-                                description: Rename a key/value pair with key KEY
-                                  to RENAMED_KEY if KEY exists. If RENAMED_KEY already
-                                  exists, this field is overwritten
+                                description: Rename a key/value pair with key KEY to RENAMED_KEY if KEY exists. If RENAMED_KEY already exists, this field is overwritten
                                 type: object
                               remove:
-                                description: Remove a key/value pair with key KEY
-                                  if it exists
+                                description: Remove a key/value pair with key KEY if it exists
                                 type: string
                               removeRegex:
-                                description: Remove all key/value pairs with key matching
-                                  regexp KEY
+                                description: Remove all key/value pairs with key matching regexp KEY
                                 type: string
                               removeWildcard:
-                                description: Remove all key/value pairs with key matching
-                                  wildcard KEY
+                                description: Remove all key/value pairs with key matching wildcard KEY
                                 type: string
                               rename:
                                 additionalProperties:
                                   type: string
-                                description: Rename a key/value pair with key KEY
-                                  to RENAMED_KEY if KEY exists AND RENAMED_KEY does
-                                  not exist
+                                description: Rename a key/value pair with key KEY to RENAMED_KEY if KEY exists AND RENAMED_KEY does not exist
                                 type: object
                               set:
                                 additionalProperties:
                                   type: string
-                                description: Add a key/value pair with key KEY and
-                                  value VALUE. If KEY already exists, this field is
-                                  overwritten
+                                description: Add a key/value pair with key KEY and value VALUE. If KEY already exists, this field is overwritten
                                 type: object
                             type: object
                           type: array
@@ -329,12 +256,10 @@ spec:
                           description: Prefix affected keys with this string
                           type: string
                         nestUnder:
-                          description: Nest records matching the Wildcard under this
-                            key
+                          description: Nest records matching the Wildcard under this key
                           type: string
                         nestedUnder:
-                          description: Lift records nested under the Nested_under
-                            key
+                          description: Lift records nested under the Nested_under key
                           type: string
                         operation:
                           description: Select the operation nest or lift
@@ -343,8 +268,7 @@ spec:
                           - lift
                           type: string
                         removePrefix:
-                          description: Remove prefix from affected keys if it matches
-                            this string
+                          description: Remove prefix from affected keys if it matches this string
                           type: string
                         wildcard:
                           description: Nest records which field matches the wildcard
@@ -359,28 +283,23 @@ spec:
                           description: Specify field name in record to parse.
                           type: string
                         parser:
-                          description: Specify the parser name to interpret the field.
-                            Multiple Parser entries are allowed (split by comma).
+                          description: Specify the parser name to interpret the field. Multiple Parser entries are allowed (split by comma).
                           type: string
                         preserveKey:
-                          description: Keep original Key_Name field in the parsed
-                            result. If false, the field will be removed.
+                          description: Keep original Key_Name field in the parsed result. If false, the field will be removed.
                           type: boolean
                         reserveData:
-                          description: Keep all other original fields in the parsed
-                            result. If false, all other original fields will be removed.
+                          description: Keep all other original fields in the parsed result. If false, all other original fields will be removed.
                           type: boolean
                         unescapeKey:
-                          description: 'If the key is a escaped string (e.g: stringify
-                            JSON), unescape the string before to apply the parser.'
+                          description: 'If the key is a escaped string (e.g: stringify JSON), unescape the string before to apply the parser.'
                           type: boolean
                       type: object
                     recordModifier:
                       description: RecordModifier defines Record Modifier Filter configuration.
                       properties:
                         records:
-                          description: Append fields. This parameter needs key and
-                            value pair.
+                          description: Append fields. This parameter needs key and value pair.
                           items:
                             type: string
                           type: array
@@ -399,34 +318,28 @@ spec:
                       description: Throttle defines a Throttle configuration.
                       properties:
                         interval:
-                          description: Interval is the time interval expressed in
-                            "sleep" format. e.g. 3s, 1.5m, 0.5h, etc.
+                          description: Interval is the time interval expressed in "sleep" format. e.g. 3s, 1.5m, 0.5h, etc.
                           pattern: ^\d+(\.[0-9]{0,2})?(s|m|h|d)?$
                           type: string
                         printStatus:
-                          description: PrintStatus represents whether to print status
-                            messages with current rate and the limits to information
-                            logs.
+                          description: PrintStatus represents whether to print status messages with current rate and the limits to information logs.
                           type: boolean
                         rate:
                           description: Rate is the amount of messages for the time.
                           format: int64
                           type: integer
                         window:
-                          description: Window is the amount of intervals to calculate
-                            average over.
+                          description: Window is the amount of intervals to calculate average over.
                           format: int64
                           type: integer
                       type: object
                   type: object
                 type: array
               match:
-                description: A pattern to match against the tags of incoming records.
-                  It's case sensitive and support the star (*) character as a wildcard.
+                description: A pattern to match against the tags of incoming records. It's case sensitive and support the star (*) character as a wildcard.
                 type: string
               matchRegex:
-                description: A regular expression to match against the tags of incoming
-                  records. Use this option if you want to use the full regex syntax.
+                description: A regular expression to match against the tags of incoming records. Use this option if you want to use the full regex syntax.
                 type: string
             type: object
         type: object
@@ -462,14 +375,10 @@ spec:
         description: FluentBitConfig is the Schema for the fluentbitconfigs API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -480,28 +389,18 @@ spec:
                 description: Select filter plugins
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements.
-                      The requirements are ANDed.
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies
-                            to.
+                          description: key is the label key that the selector applies to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
-                            merge patch.
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                           items:
                             type: string
                           type: array
@@ -513,39 +412,25 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
               inputSelector:
                 description: Select input plugins
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements.
-                      The requirements are ANDed.
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies
-                            to.
+                          description: key is the label key that the selector applies to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
-                            merge patch.
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                           items:
                             type: string
                           type: array
@@ -557,39 +442,25 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
               outputSelector:
                 description: Select output plugins
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements.
-                      The requirements are ANDed.
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies
-                            to.
+                          description: key is the label key that the selector applies to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
-                            merge patch.
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                           items:
                             type: string
                           type: array
@@ -601,39 +472,25 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
               parserSelector:
                 description: Select parser plugins
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements.
-                      The requirements are ANDed.
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies
-                            to.
+                          description: key is the label key that the selector applies to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
-                            merge patch.
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                           items:
                             type: string
                           type: array
@@ -645,16 +502,11 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
               service:
-                description: Service defines the global behaviour of the Fluent Bit
-                  engine.
+                description: Service defines the global behaviour of the Fluent Bit engine.
                 properties:
                   daemon:
                     description: If true go to background on start
@@ -730,14 +582,10 @@ spec:
         description: FluentBit is the Schema for the fluentbits API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -748,59 +596,29 @@ spec:
                 description: Pod's scheduling constraints.
                 properties:
                   nodeAffinity:
-                    description: Describes node affinity scheduling rules for the
-                      pod.
+                    description: Describes node affinity scheduling rules for the pod.
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to
-                          nodes that satisfy the affinity expressions specified by
-                          this field, but it may choose a node that violates one or
-                          more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node matches
-                          the corresponding matchExpressions; the node(s) with the
-                          highest sum are the most preferred.
+                        description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
                         items:
-                          description: An empty preferred scheduling term matches
-                            all objects with implicit weight 0 (i.e. it's a no-op).
-                            A null preferred scheduling term matches no objects (i.e.
-                            is also a no-op).
+                          description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                           properties:
                             preference:
-                              description: A node selector term, associated with the
-                                corresponding weight.
+                              description: A node selector term, associated with the corresponding weight.
                               properties:
                                 matchExpressions:
-                                  description: A list of node selector requirements
-                                    by node's labels.
+                                  description: A list of node selector requirements by node's labels.
                                   items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
+                                    description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector
-                                          applies to.
+                                        description: The label key that the selector applies to.
                                         type: string
                                       operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
+                                        description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
+                                        description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -810,33 +628,18 @@ spec:
                                     type: object
                                   type: array
                                 matchFields:
-                                  description: A list of node selector requirements
-                                    by node's fields.
+                                  description: A list of node selector requirements by node's fields.
                                   items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
+                                    description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector
-                                          applies to.
+                                        description: The label key that the selector applies to.
                                         type: string
                                       operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
+                                        description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
+                                        description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -847,8 +650,7 @@ spec:
                                   type: array
                               type: object
                             weight:
-                              description: Weight associated with matching the corresponding
-                                nodeSelectorTerm, in the range 1-100.
+                              description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -857,50 +659,26 @@ spec:
                           type: object
                         type: array
                       requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the affinity requirements specified by this
-                          field are not met at scheduling time, the pod will not be
-                          scheduled onto the node. If the affinity requirements specified
-                          by this field cease to be met at some point during pod execution
-                          (e.g. due to an update), the system may or may not try to
-                          eventually evict the pod from its node.
+                        description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
                         properties:
                           nodeSelectorTerms:
-                            description: Required. A list of node selector terms.
-                              The terms are ORed.
+                            description: Required. A list of node selector terms. The terms are ORed.
                             items:
-                              description: A null or empty node selector term matches
-                                no objects. The requirements of them are ANDed. The
-                                TopologySelectorTerm type implements a subset of the
-                                NodeSelectorTerm.
+                              description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                               properties:
                                 matchExpressions:
-                                  description: A list of node selector requirements
-                                    by node's labels.
+                                  description: A list of node selector requirements by node's labels.
                                   items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
+                                    description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector
-                                          applies to.
+                                        description: The label key that the selector applies to.
                                         type: string
                                       operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
+                                        description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
+                                        description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -910,33 +688,18 @@ spec:
                                     type: object
                                   type: array
                                 matchFields:
-                                  description: A list of node selector requirements
-                                    by node's fields.
+                                  description: A list of node selector requirements by node's fields.
                                   items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
+                                    description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector
-                                          applies to.
+                                        description: The label key that the selector applies to.
                                         type: string
                                       operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
+                                        description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
+                                        description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -952,61 +715,32 @@ spec:
                         type: object
                     type: object
                   podAffinity:
-                    description: Describes pod affinity scheduling rules (e.g. co-locate
-                      this pod in the same node, zone, etc. as some other pod(s)).
+                    description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to
-                          nodes that satisfy the affinity expressions specified by
-                          this field, but it may choose a node that violates one or
-                          more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node has
-                          pods which matches the corresponding podAffinityTerm; the
-                          node(s) with the highest sum are the most preferred.
+                        description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
                         items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm
-                            fields are added per-node to find the most preferred node(s)
+                          description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
                           properties:
                             podAffinityTerm:
-                              description: Required. A pod affinity term, associated
-                                with the corresponding weight.
+                              description: Required. A pod affinity term, associated with the corresponding weight.
                               properties:
                                 labelSelector:
-                                  description: A label query over a set of resources,
-                                    in this case pods.
+                                  description: A label query over a set of resources, in this case pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                       items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
+                                            description: key is the label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -1018,36 +752,22 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                 namespaces:
-                                  description: namespaces specifies which namespaces
-                                    the labelSelector applies to (matches against);
-                                    null or empty list means "this pod's namespace"
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                   items:
                                     type: string
                                   type: array
                                 topologyKey:
-                                  description: This pod should be co-located (affinity)
-                                    or not co-located (anti-affinity) with the pods
-                                    matching the labelSelector in the specified namespaces,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey
-                                    matches that of any node on which any of the selected
-                                    pods is running. Empty topologyKey is not allowed.
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                   type: string
                               required:
                               - topologyKey
                               type: object
                             weight:
-                              description: weight associated with matching the corresponding
-                                podAffinityTerm, in the range 1-100.
+                              description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -1056,52 +776,26 @@ spec:
                           type: object
                         type: array
                       requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the affinity requirements specified by this
-                          field are not met at scheduling time, the pod will not be
-                          scheduled onto the node. If the affinity requirements specified
-                          by this field cease to be met at some point during pod execution
-                          (e.g. due to a pod label update), the system may or may
-                          not try to eventually evict the pod from its node. When
-                          there are multiple elements, the lists of nodes corresponding
-                          to each podAffinityTerm are intersected, i.e. all terms
-                          must be satisfied.
+                        description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
                         items:
-                          description: Defines a set of pods (namely those matching
-                            the labelSelector relative to the given namespace(s))
-                            that this pod should be co-located (affinity) or not co-located
-                            (anti-affinity) with, where co-located is defined as running
-                            on a node whose value of the label with key <topologyKey>
-                            matches that of any node on which a pod of the set of
-                            pods is running
+                          description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
                           properties:
                             labelSelector:
-                              description: A label query over a set of resources,
-                                in this case pods.
+                              description: A label query over a set of resources, in this case pods.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
+                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
+                                        description: key is the label key that the selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
+                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -1113,29 +807,16 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
+                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                             namespaces:
-                              description: namespaces specifies which namespaces the
-                                labelSelector applies to (matches against); null or
-                                empty list means "this pod's namespace"
+                              description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                               items:
                                 type: string
                               type: array
                             topologyKey:
-                              description: This pod should be co-located (affinity)
-                                or not co-located (anti-affinity) with the pods matching
-                                the labelSelector in the specified namespaces, where
-                                co-located is defined as running on a node whose value
-                                of the label with key topologyKey matches that of
-                                any node on which any of the selected pods is running.
-                                Empty topologyKey is not allowed.
+                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                               type: string
                           required:
                           - topologyKey
@@ -1143,62 +824,32 @@ spec:
                         type: array
                     type: object
                   podAntiAffinity:
-                    description: Describes pod anti-affinity scheduling rules (e.g.
-                      avoid putting this pod in the same node, zone, etc. as some
-                      other pod(s)).
+                    description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to
-                          nodes that satisfy the anti-affinity expressions specified
-                          by this field, but it may choose a node that violates one
-                          or more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling anti-affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node has
-                          pods which matches the corresponding podAffinityTerm; the
-                          node(s) with the highest sum are the most preferred.
+                        description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
                         items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm
-                            fields are added per-node to find the most preferred node(s)
+                          description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
                           properties:
                             podAffinityTerm:
-                              description: Required. A pod affinity term, associated
-                                with the corresponding weight.
+                              description: Required. A pod affinity term, associated with the corresponding weight.
                               properties:
                                 labelSelector:
-                                  description: A label query over a set of resources,
-                                    in this case pods.
+                                  description: A label query over a set of resources, in this case pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                       items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
+                                            description: key is the label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -1210,36 +861,22 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                 namespaces:
-                                  description: namespaces specifies which namespaces
-                                    the labelSelector applies to (matches against);
-                                    null or empty list means "this pod's namespace"
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                   items:
                                     type: string
                                   type: array
                                 topologyKey:
-                                  description: This pod should be co-located (affinity)
-                                    or not co-located (anti-affinity) with the pods
-                                    matching the labelSelector in the specified namespaces,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey
-                                    matches that of any node on which any of the selected
-                                    pods is running. Empty topologyKey is not allowed.
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                   type: string
                               required:
                               - topologyKey
                               type: object
                             weight:
-                              description: weight associated with matching the corresponding
-                                podAffinityTerm, in the range 1-100.
+                              description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -1248,52 +885,26 @@ spec:
                           type: object
                         type: array
                       requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the anti-affinity requirements specified by
-                          this field are not met at scheduling time, the pod will
-                          not be scheduled onto the node. If the anti-affinity requirements
-                          specified by this field cease to be met at some point during
-                          pod execution (e.g. due to a pod label update), the system
-                          may or may not try to eventually evict the pod from its
-                          node. When there are multiple elements, the lists of nodes
-                          corresponding to each podAffinityTerm are intersected, i.e.
-                          all terms must be satisfied.
+                        description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
                         items:
-                          description: Defines a set of pods (namely those matching
-                            the labelSelector relative to the given namespace(s))
-                            that this pod should be co-located (affinity) or not co-located
-                            (anti-affinity) with, where co-located is defined as running
-                            on a node whose value of the label with key <topologyKey>
-                            matches that of any node on which a pod of the set of
-                            pods is running
+                          description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
                           properties:
                             labelSelector:
-                              description: A label query over a set of resources,
-                                in this case pods.
+                              description: A label query over a set of resources, in this case pods.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
+                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
+                                        description: key is the label key that the selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
+                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -1305,29 +916,16 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
+                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                             namespaces:
-                              description: namespaces specifies which namespaces the
-                                labelSelector applies to (matches against); null or
-                                empty list means "this pod's namespace"
+                              description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                               items:
                                 type: string
                               type: array
                             topologyKey:
-                              description: This pod should be co-located (affinity)
-                                or not co-located (anti-affinity) with the pods matching
-                                the labelSelector in the specified namespaces, where
-                                co-located is defined as running on a node whose value
-                                of the label with key topologyKey matches that of
-                                any node on which any of the selected pods is running.
-                                Empty topologyKey is not allowed.
+                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                               type: string
                           required:
                           - topologyKey
@@ -1350,12 +948,10 @@ spec:
               imagePullSecrets:
                 description: Fluent Bit image pull secret
                 items:
-                  description: LocalObjectReference contains enough information to
-                    let you locate the referenced object inside the same namespace.
+                  description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
                   properties:
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                       type: string
                   type: object
                 type: array
@@ -1365,46 +961,29 @@ spec:
                 description: NodeSelector
                 type: object
               positionDB:
-                description: Storage for position db. You will use it if tail input
-                  is enabled.
+                description: Storage for position db. You will use it if tail input is enabled.
                 properties:
                   awsElasticBlockStore:
-                    description: 'AWSElasticBlockStore represents an AWS Disk resource
-                      that is attached to a kubelet''s host machine and then exposed
-                      to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                    description: 'AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                     properties:
                       fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                          TODO: how do we prevent errors in the filesystem from compromising
-                          the machine'
+                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine'
                         type: string
                       partition:
-                        description: 'The partition in the volume that you want to
-                          mount. If omitted, the default is to mount by volume name.
-                          Examples: For volume /dev/sda1, you specify the partition
-                          as "1". Similarly, the volume partition for /dev/sda is
-                          "0" (or you can leave the property empty).'
+                        description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
                         format: int32
                         type: integer
                       readOnly:
-                        description: 'Specify "true" to force and set the ReadOnly
-                          property in VolumeMounts to "true". If omitted, the default
-                          is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                        description: 'Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                         type: boolean
                       volumeID:
-                        description: 'Unique ID of the persistent disk resource in
-                          AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                        description: 'Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                         type: string
                     required:
                     - volumeID
                     type: object
                   azureDisk:
-                    description: AzureDisk represents an Azure Data Disk mount on
-                      the host and bind mount to the pod.
+                    description: AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
                     properties:
                       cachingMode:
                         description: 'Host Caching mode: None, Read Only, Read Write.'
@@ -1416,35 +995,26 @@ spec:
                         description: The URI the data disk in the blob storage
                         type: string
                       fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                         type: string
                       kind:
-                        description: 'Expected values Shared: multiple blob disks
-                          per storage account  Dedicated: single blob disk per storage
-                          account  Managed: azure managed data disk (only in managed
-                          availability set). defaults to shared'
+                        description: 'Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
                         type: string
                       readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
+                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                         type: boolean
                     required:
                     - diskName
                     - diskURI
                     type: object
                   azureFile:
-                    description: AzureFile represents an Azure File Service mount
-                      on the host and bind mount to the pod.
+                    description: AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
                     properties:
                       readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
+                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                         type: boolean
                       secretName:
-                        description: the name of secret that contains Azure Storage
-                          Account Name and Key
+                        description: the name of secret that contains Azure Storage Account Name and Key
                         type: string
                       shareName:
                         description: Share Name
@@ -1454,98 +1024,66 @@ spec:
                     - shareName
                     type: object
                   cephfs:
-                    description: CephFS represents a Ceph FS mount on the host that
-                      shares a pod's lifetime
+                    description: CephFS represents a Ceph FS mount on the host that shares a pod's lifetime
                     properties:
                       monitors:
-                        description: 'Required: Monitors is a collection of Ceph monitors
-                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        description: 'Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                         items:
                           type: string
                         type: array
                       path:
-                        description: 'Optional: Used as the mounted root, rather than
-                          the full Ceph tree, default is /'
+                        description: 'Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
                         type: string
                       readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts. More
-                          info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                         type: boolean
                       secretFile:
-                        description: 'Optional: SecretFile is the path to key ring
-                          for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        description: 'Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                         type: string
                       secretRef:
-                        description: 'Optional: SecretRef is reference to the authentication
-                          secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        description: 'Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                         properties:
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                       user:
-                        description: 'Optional: User is the rados user name, default
-                          is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        description: 'Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                         type: string
                     required:
                     - monitors
                     type: object
                   cinder:
-                    description: 'Cinder represents a cinder volume attached and mounted
-                      on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                    description: 'Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                     properties:
                       fsType:
-                        description: 'Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Examples: "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                        description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                         type: string
                       readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts. More
-                          info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                         type: boolean
                       secretRef:
-                        description: 'Optional: points to a secret object containing
-                          parameters used to connect to OpenStack.'
+                        description: 'Optional: points to a secret object containing parameters used to connect to OpenStack.'
                         properties:
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                       volumeID:
-                        description: 'volume id used to identify the volume in cinder.
-                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                        description: 'volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                         type: string
                     required:
                     - volumeID
                     type: object
                   configMap:
-                    description: ConfigMap represents a configMap that should populate
-                      this volume
+                    description: ConfigMap represents a configMap that should populate this volume
                     properties:
                       defaultMode:
-                        description: 'Optional: mode bits to use on created files
-                          by default. Must be a value between 0 and 0777. Defaults
-                          to 0644. Directories within the path are not affected by
-                          this setting. This might be in conflict with other options
-                          that affect the file mode, like fsGroup, and the result
-                          can be other mode bits set.'
+                        description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                         format: int32
                         type: integer
                       items:
-                        description: If unspecified, each key-value pair in the Data
-                          field of the referenced ConfigMap will be projected into
-                          the volume as a file whose name is the key and content is
-                          the value. If specified, the listed keys will be projected
-                          into the specified paths, and unlisted keys will not be
-                          present. If a key is specified which is not present in the
-                          ConfigMap, the volume setup will error unless it is marked
-                          optional. Paths must be relative and may not contain the
-                          '..' path or start with '..'.
+                        description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                         items:
                           description: Maps a string key to a path within a volume.
                           properties:
@@ -1553,19 +1091,11 @@ spec:
                               description: The key to project.
                               type: string
                             mode:
-                              description: 'Optional: mode bits to use on this file,
-                                must be a value between 0 and 0777. If not specified,
-                                the volume defaultMode will be used. This might be
-                                in conflict with other options that affect the file
-                                mode, like fsGroup, and the result can be other mode
-                                bits set.'
+                              description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                               format: int32
                               type: integer
                             path:
-                              description: The relative path of the file to map the
-                                key to. May not be an absolute path. May not contain
-                                the path element '..'. May not start with the string
-                                '..'.
+                              description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                               type: string
                           required:
                           - key
@@ -1573,121 +1103,81 @@ spec:
                           type: object
                         type: array
                       name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                       optional:
-                        description: Specify whether the ConfigMap or its keys must
-                          be defined
+                        description: Specify whether the ConfigMap or its keys must be defined
                         type: boolean
                     type: object
                   csi:
-                    description: CSI (Container Storage Interface) represents storage
-                      that is handled by an external CSI driver (Alpha feature).
+                    description: CSI (Container Storage Interface) represents storage that is handled by an external CSI driver (Alpha feature).
                     properties:
                       driver:
-                        description: Driver is the name of the CSI driver that handles
-                          this volume. Consult with your admin for the correct name
-                          as registered in the cluster.
+                        description: Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
                         type: string
                       fsType:
-                        description: Filesystem type to mount. Ex. "ext4", "xfs",
-                          "ntfs". If not provided, the empty value is passed to the
-                          associated CSI driver which will determine the default filesystem
-                          to apply.
+                        description: Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
                         type: string
                       nodePublishSecretRef:
-                        description: NodePublishSecretRef is a reference to the secret
-                          object containing sensitive information to pass to the CSI
-                          driver to complete the CSI NodePublishVolume and NodeUnpublishVolume
-                          calls. This field is optional, and  may be empty if no secret
-                          is required. If the secret object contains more than one
-                          secret, all secret references are passed.
+                        description: NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
                         properties:
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                       readOnly:
-                        description: Specifies a read-only configuration for the volume.
-                          Defaults to false (read/write).
+                        description: Specifies a read-only configuration for the volume. Defaults to false (read/write).
                         type: boolean
                       volumeAttributes:
                         additionalProperties:
                           type: string
-                        description: VolumeAttributes stores driver-specific properties
-                          that are passed to the CSI driver. Consult your driver's
-                          documentation for supported values.
+                        description: VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
                         type: object
                     required:
                     - driver
                     type: object
                   downwardAPI:
-                    description: DownwardAPI represents downward API about the pod
-                      that should populate this volume
+                    description: DownwardAPI represents downward API about the pod that should populate this volume
                     properties:
                       defaultMode:
-                        description: 'Optional: mode bits to use on created files
-                          by default. Must be a value between 0 and 0777. Defaults
-                          to 0644. Directories within the path are not affected by
-                          this setting. This might be in conflict with other options
-                          that affect the file mode, like fsGroup, and the result
-                          can be other mode bits set.'
+                        description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                         format: int32
                         type: integer
                       items:
                         description: Items is a list of downward API volume file
                         items:
-                          description: DownwardAPIVolumeFile represents information
-                            to create the file containing the pod field
+                          description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                           properties:
                             fieldRef:
-                              description: 'Required: Selects a field of the pod:
-                                only annotations, labels, name and namespace are supported.'
+                              description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
                               properties:
                                 apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
+                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
+                                  description: Path of the field to select in the specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                             mode:
-                              description: 'Optional: mode bits to use on this file,
-                                must be a value between 0 and 0777. If not specified,
-                                the volume defaultMode will be used. This might be
-                                in conflict with other options that affect the file
-                                mode, like fsGroup, and the result can be other mode
-                                bits set.'
+                              description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                               format: int32
                               type: integer
                             path:
-                              description: 'Required: Path is  the relative path name
-                                of the file to be created. Must not be absolute or
-                                contain the ''..'' path. Must be utf-8 encoded. The
-                                first item of the relative path must not start with
-                                ''..'''
+                              description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
                               type: string
                             resourceFieldRef:
-                              description: 'Selects a resource of the container: only
-                                resources limits and requests (limits.cpu, limits.memory,
-                                requests.cpu and requests.memory) are currently supported.'
+                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
                               properties:
                                 containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
+                                  description: 'Container name: required for volumes, optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
+                                  description: Specifies the output format of the exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
@@ -1702,47 +1192,31 @@ spec:
                         type: array
                     type: object
                   emptyDir:
-                    description: 'EmptyDir represents a temporary directory that shares
-                      a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                    description: 'EmptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                     properties:
                       medium:
-                        description: 'What type of storage medium should back this
-                          directory. The default is "" which means to use the node''s
-                          default medium. Must be an empty string (default) or Memory.
-                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                        description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                         type: string
                       sizeLimit:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'Total amount of local storage required for this
-                          EmptyDir volume. The size limit is also applicable for memory
-                          medium. The maximum usage on memory medium EmptyDir would
-                          be the minimum value between the SizeLimit specified here
-                          and the sum of memory limits of all containers in a pod.
-                          The default is nil which means that the limit is undefined.
-                          More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                        description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                     type: object
                   fc:
-                    description: FC represents a Fibre Channel resource that is attached
-                      to a kubelet's host machine and then exposed to the pod.
+                    description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
                     properties:
                       fsType:
-                        description: 'Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          TODO: how do we prevent errors in the filesystem from compromising
-                          the machine'
+                        description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine'
                         type: string
                       lun:
                         description: 'Optional: FC target lun number'
                         format: int32
                         type: integer
                       readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts.'
+                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                         type: boolean
                       targetWWNs:
                         description: 'Optional: FC target worldwide names (WWNs)'
@@ -1750,26 +1224,19 @@ spec:
                           type: string
                         type: array
                       wwids:
-                        description: 'Optional: FC volume world wide identifiers (wwids)
-                          Either wwids or combination of targetWWNs and lun must be
-                          set, but not both simultaneously.'
+                        description: 'Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
                         items:
                           type: string
                         type: array
                     type: object
                   flexVolume:
-                    description: FlexVolume represents a generic volume resource that
-                      is provisioned/attached using an exec based plugin.
+                    description: FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
                     properties:
                       driver:
-                        description: Driver is the name of the driver to use for this
-                          volume.
+                        description: Driver is the name of the driver to use for this volume.
                         type: string
                       fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". The default filesystem depends on FlexVolume
-                          script.
+                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                         type: string
                       options:
                         additionalProperties:
@@ -1777,84 +1244,52 @@ spec:
                         description: 'Optional: Extra command options if any.'
                         type: object
                       readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts.'
+                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                         type: boolean
                       secretRef:
-                        description: 'Optional: SecretRef is reference to the secret
-                          object containing sensitive information to pass to the plugin
-                          scripts. This may be empty if no secret object is specified.
-                          If the secret object contains more than one secret, all
-                          secrets are passed to the plugin scripts.'
+                        description: 'Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
                         properties:
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                     required:
                     - driver
                     type: object
                   flocker:
-                    description: Flocker represents a Flocker volume attached to a
-                      kubelet's host machine. This depends on the Flocker control
-                      service being running
+                    description: Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
                     properties:
                       datasetName:
-                        description: Name of the dataset stored as metadata -> name
-                          on the dataset for Flocker should be considered as deprecated
+                        description: Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
                         type: string
                       datasetUUID:
-                        description: UUID of the dataset. This is unique identifier
-                          of a Flocker dataset
+                        description: UUID of the dataset. This is unique identifier of a Flocker dataset
                         type: string
                     type: object
                   gcePersistentDisk:
-                    description: 'GCEPersistentDisk represents a GCE Disk resource
-                      that is attached to a kubelet''s host machine and then exposed
-                      to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                    description: 'GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                     properties:
                       fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                          TODO: how do we prevent errors in the filesystem from compromising
-                          the machine'
+                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine'
                         type: string
                       partition:
-                        description: 'The partition in the volume that you want to
-                          mount. If omitted, the default is to mount by volume name.
-                          Examples: For volume /dev/sda1, you specify the partition
-                          as "1". Similarly, the volume partition for /dev/sda is
-                          "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                         format: int32
                         type: integer
                       pdName:
-                        description: 'Unique name of the PD resource in GCE. Used
-                          to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        description: 'Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                         type: string
                       readOnly:
-                        description: 'ReadOnly here will force the ReadOnly setting
-                          in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                         type: boolean
                     required:
                     - pdName
                     type: object
                   gitRepo:
-                    description: 'GitRepo represents a git repository at a particular
-                      revision. DEPRECATED: GitRepo is deprecated. To provision a
-                      container with a git repo, mount an EmptyDir into an InitContainer
-                      that clones the repo using git, then mount the EmptyDir into
-                      the Pod''s container.'
+                    description: 'GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
                     properties:
                       directory:
-                        description: Target directory name. Must not contain or start
-                          with '..'.  If '.' is supplied, the volume directory will
-                          be the git repository.  Otherwise, if specified, the volume
-                          will contain the git repository in the subdirectory with
-                          the given name.
+                        description: Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
                         type: string
                       repository:
                         description: Repository URL
@@ -1866,51 +1301,35 @@ spec:
                     - repository
                     type: object
                   glusterfs:
-                    description: 'Glusterfs represents a Glusterfs mount on the host
-                      that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                    description: 'Glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                     properties:
                       endpoints:
-                        description: 'EndpointsName is the endpoint name that details
-                          Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                        description: 'EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                         type: string
                       path:
-                        description: 'Path is the Glusterfs volume path. More info:
-                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                        description: 'Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                         type: string
                       readOnly:
-                        description: 'ReadOnly here will force the Glusterfs volume
-                          to be mounted with read-only permissions. Defaults to false.
-                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                        description: 'ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                         type: boolean
                     required:
                     - endpoints
                     - path
                     type: object
                   hostPath:
-                    description: 'HostPath represents a pre-existing file or directory
-                      on the host machine that is directly exposed to the container.
-                      This is generally used for system agents or other privileged
-                      things that are allowed to see the host machine. Most containers
-                      will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                      --- TODO(jonesdl) We need to restrict who can use host directory
-                      mounts and who can/can not mount host directories as read/write.'
+                    description: 'HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.'
                     properties:
                       path:
-                        description: 'Path of the directory on the host. If the path
-                          is a symlink, it will follow the link to the real path.
-                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                        description: 'Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                         type: string
                       type:
-                        description: 'Type for HostPath Volume Defaults to "" More
-                          info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                        description: 'Type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                         type: string
                     required:
                     - path
                     type: object
                   iscsi:
-                    description: 'ISCSI represents an ISCSI Disk resource that is
-                      attached to a kubelet''s host machine and then exposed to the
-                      pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                    description: 'ISCSI represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                     properties:
                       chapAuthDiscovery:
                         description: whether support iSCSI Discovery CHAP authentication
@@ -1919,54 +1338,38 @@ spec:
                         description: whether support iSCSI Session CHAP authentication
                         type: boolean
                       fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                          TODO: how do we prevent errors in the filesystem from compromising
-                          the machine'
+                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine'
                         type: string
                       initiatorName:
-                        description: Custom iSCSI Initiator Name. If initiatorName
-                          is specified with iscsiInterface simultaneously, new iSCSI
-                          interface <target portal>:<volume name> will be created
-                          for the connection.
+                        description: Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
                         type: string
                       iqn:
                         description: Target iSCSI Qualified Name.
                         type: string
                       iscsiInterface:
-                        description: iSCSI Interface Name that uses an iSCSI transport.
-                          Defaults to 'default' (tcp).
+                        description: iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
                         type: string
                       lun:
                         description: iSCSI Target Lun number.
                         format: int32
                         type: integer
                       portals:
-                        description: iSCSI Target Portal List. The portal is either
-                          an IP or ip_addr:port if the port is other than default
-                          (typically TCP ports 860 and 3260).
+                        description: iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                         items:
                           type: string
                         type: array
                       readOnly:
-                        description: ReadOnly here will force the ReadOnly setting
-                          in VolumeMounts. Defaults to false.
+                        description: ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
                         type: boolean
                       secretRef:
                         description: CHAP Secret for iSCSI target and initiator authentication
                         properties:
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                       targetPortal:
-                        description: iSCSI Target Portal. The Portal is either an
-                          IP or ip_addr:port if the port is other than default (typically
-                          TCP ports 860 and 3260).
+                        description: iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                         type: string
                     required:
                     - iqn
@@ -1974,72 +1377,53 @@ spec:
                     - targetPortal
                     type: object
                   nfs:
-                    description: 'NFS represents an NFS mount on the host that shares
-                      a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                    description: 'NFS represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                     properties:
                       path:
-                        description: 'Path that is exported by the NFS server. More
-                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        description: 'Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                         type: string
                       readOnly:
-                        description: 'ReadOnly here will force the NFS export to be
-                          mounted with read-only permissions. Defaults to false. More
-                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        description: 'ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                         type: boolean
                       server:
-                        description: 'Server is the hostname or IP address of the
-                          NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        description: 'Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                         type: string
                     required:
                     - path
                     - server
                     type: object
                   persistentVolumeClaim:
-                    description: 'PersistentVolumeClaimVolumeSource represents a reference
-                      to a PersistentVolumeClaim in the same namespace. More info:
-                      https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                    description: 'PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                     properties:
                       claimName:
-                        description: 'ClaimName is the name of a PersistentVolumeClaim
-                          in the same namespace as the pod using this volume. More
-                          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                        description: 'ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                         type: string
                       readOnly:
-                        description: Will force the ReadOnly setting in VolumeMounts.
-                          Default false.
+                        description: Will force the ReadOnly setting in VolumeMounts. Default false.
                         type: boolean
                     required:
                     - claimName
                     type: object
                   photonPersistentDisk:
-                    description: PhotonPersistentDisk represents a PhotonController
-                      persistent disk attached and mounted on kubelets host machine
+                    description: PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
                     properties:
                       fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                         type: string
                       pdID:
-                        description: ID that identifies Photon Controller persistent
-                          disk
+                        description: ID that identifies Photon Controller persistent disk
                         type: string
                     required:
                     - pdID
                     type: object
                   portworxVolume:
-                    description: PortworxVolume represents a portworx volume attached
-                      and mounted on kubelets host machine
+                    description: PortworxVolume represents a portworx volume attached and mounted on kubelets host machine
                     properties:
                       fsType:
-                        description: FSType represents the filesystem type to mount
-                          Must be a filesystem type supported by the host operating
-                          system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
-                          if unspecified.
+                        description: FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                         type: string
                       readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
+                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                         type: boolean
                       volumeID:
                         description: VolumeID uniquely identifies a Portworx volume
@@ -2048,61 +1432,34 @@ spec:
                     - volumeID
                     type: object
                   projected:
-                    description: Items for all in one resources secrets, configmaps,
-                      and downward API
+                    description: Items for all in one resources secrets, configmaps, and downward API
                     properties:
                       defaultMode:
-                        description: Mode bits to use on created files by default.
-                          Must be a value between 0 and 0777. Directories within the
-                          path are not affected by this setting. This might be in
-                          conflict with other options that affect the file mode, like
-                          fsGroup, and the result can be other mode bits set.
+                        description: Mode bits to use on created files by default. Must be a value between 0 and 0777. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
                         format: int32
                         type: integer
                       sources:
                         description: list of volume projections
                         items:
-                          description: Projection that may be projected along with
-                            other supported volume types
+                          description: Projection that may be projected along with other supported volume types
                           properties:
                             configMap:
-                              description: information about the configMap data to
-                                project
+                              description: information about the configMap data to project
                               properties:
                                 items:
-                                  description: If unspecified, each key-value pair
-                                    in the Data field of the referenced ConfigMap
-                                    will be projected into the volume as a file whose
-                                    name is the key and content is the value. If specified,
-                                    the listed keys will be projected into the specified
-                                    paths, and unlisted keys will not be present.
-                                    If a key is specified which is not present in
-                                    the ConfigMap, the volume setup will error unless
-                                    it is marked optional. Paths must be relative
-                                    and may not contain the '..' path or start with
-                                    '..'.
+                                  description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
+                                    description: Maps a string key to a path within a volume.
                                     properties:
                                       key:
                                         description: The key to project.
                                         type: string
                                       mode:
-                                        description: 'Optional: mode bits to use on
-                                          this file, must be a value between 0 and
-                                          0777. If not specified, the volume defaultMode
-                                          will be used. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
+                                        description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: The relative path of the file
-                                          to map the key to. May not be an absolute
-                                          path. May not contain the path element '..'.
-                                          May not start with the string '..'.
+                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -2110,78 +1467,50 @@ spec:
                                     type: object
                                   type: array
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    keys must be defined
+                                  description: Specify whether the ConfigMap or its keys must be defined
                                   type: boolean
                               type: object
                             downwardAPI:
-                              description: information about the downwardAPI data
-                                to project
+                              description: information about the downwardAPI data to project
                               properties:
                                 items:
-                                  description: Items is a list of DownwardAPIVolume
-                                    file
+                                  description: Items is a list of DownwardAPIVolume file
                                   items:
-                                    description: DownwardAPIVolumeFile represents
-                                      information to create the file containing the
-                                      pod field
+                                    description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                                     properties:
                                       fieldRef:
-                                        description: 'Required: Selects a field of
-                                          the pod: only annotations, labels, name
-                                          and namespace are supported.'
+                                        description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
                                         properties:
                                           apiVersion:
-                                            description: Version of the schema the
-                                              FieldPath is written in terms of, defaults
-                                              to "v1".
+                                            description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                             type: string
                                           fieldPath:
-                                            description: Path of the field to select
-                                              in the specified API version.
+                                            description: Path of the field to select in the specified API version.
                                             type: string
                                         required:
                                         - fieldPath
                                         type: object
                                       mode:
-                                        description: 'Optional: mode bits to use on
-                                          this file, must be a value between 0 and
-                                          0777. If not specified, the volume defaultMode
-                                          will be used. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
+                                        description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: 'Required: Path is  the relative
-                                          path name of the file to be created. Must
-                                          not be absolute or contain the ''..'' path.
-                                          Must be utf-8 encoded. The first item of
-                                          the relative path must not start with ''..'''
+                                        description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
                                         type: string
                                       resourceFieldRef:
-                                        description: 'Selects a resource of the container:
-                                          only resources limits and requests (limits.cpu,
-                                          limits.memory, requests.cpu and requests.memory)
-                                          are currently supported.'
+                                        description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
                                         properties:
                                           containerName:
-                                            description: 'Container name: required
-                                              for volumes, optional for env vars'
+                                            description: 'Container name: required for volumes, optional for env vars'
                                             type: string
                                           divisor:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Specifies the output format
-                                              of the exposed resources, defaults to
-                                              "1"
+                                            description: Specifies the output format of the exposed resources, defaults to "1"
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           resource:
@@ -2199,39 +1528,19 @@ spec:
                               description: information about the secret data to project
                               properties:
                                 items:
-                                  description: If unspecified, each key-value pair
-                                    in the Data field of the referenced Secret will
-                                    be projected into the volume as a file whose name
-                                    is the key and content is the value. If specified,
-                                    the listed keys will be projected into the specified
-                                    paths, and unlisted keys will not be present.
-                                    If a key is specified which is not present in
-                                    the Secret, the volume setup will error unless
-                                    it is marked optional. Paths must be relative
-                                    and may not contain the '..' path or start with
-                                    '..'.
+                                  description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
+                                    description: Maps a string key to a path within a volume.
                                     properties:
                                       key:
                                         description: The key to project.
                                         type: string
                                       mode:
-                                        description: 'Optional: mode bits to use on
-                                          this file, must be a value between 0 and
-                                          0777. If not specified, the volume defaultMode
-                                          will be used. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
+                                        description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: The relative path of the file
-                                          to map the key to. May not be an absolute
-                                          path. May not contain the path element '..'.
-                                          May not start with the string '..'.
+                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -2239,42 +1548,24 @@ spec:
                                     type: object
                                   type: array
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
+                                  description: Specify whether the Secret or its key must be defined
                                   type: boolean
                               type: object
                             serviceAccountToken:
-                              description: information about the serviceAccountToken
-                                data to project
+                              description: information about the serviceAccountToken data to project
                               properties:
                                 audience:
-                                  description: Audience is the intended audience of
-                                    the token. A recipient of a token must identify
-                                    itself with an identifier specified in the audience
-                                    of the token, and otherwise should reject the
-                                    token. The audience defaults to the identifier
-                                    of the apiserver.
+                                  description: Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
                                   type: string
                                 expirationSeconds:
-                                  description: ExpirationSeconds is the requested
-                                    duration of validity of the service account token.
-                                    As the token approaches expiration, the kubelet
-                                    volume plugin will proactively rotate the service
-                                    account token. The kubelet will start trying to
-                                    rotate the token if the token is older than 80
-                                    percent of its time to live or if the token is
-                                    older than 24 hours.Defaults to 1 hour and must
-                                    be at least 10 minutes.
+                                  description: ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
                                   format: int64
                                   type: integer
                                 path:
-                                  description: Path is the path relative to the mount
-                                    point of the file to project the token into.
+                                  description: Path is the path relative to the mount point of the file to project the token into.
                                   type: string
                               required:
                               - path
@@ -2285,58 +1576,41 @@ spec:
                     - sources
                     type: object
                   quobyte:
-                    description: Quobyte represents a Quobyte mount on the host that
-                      shares a pod's lifetime
+                    description: Quobyte represents a Quobyte mount on the host that shares a pod's lifetime
                     properties:
                       group:
                         description: Group to map volume access to Default is no group
                         type: string
                       readOnly:
-                        description: ReadOnly here will force the Quobyte volume to
-                          be mounted with read-only permissions. Defaults to false.
+                        description: ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
                         type: boolean
                       registry:
-                        description: Registry represents a single or multiple Quobyte
-                          Registry services specified as a string as host:port pair
-                          (multiple entries are separated with commas) which acts
-                          as the central registry for volumes
+                        description: Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
                         type: string
                       tenant:
-                        description: Tenant owning the given Quobyte volume in the
-                          Backend Used with dynamically provisioned Quobyte volumes,
-                          value is set by the plugin
+                        description: Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                         type: string
                       user:
-                        description: User to map volume access to Defaults to serivceaccount
-                          user
+                        description: User to map volume access to Defaults to serivceaccount user
                         type: string
                       volume:
-                        description: Volume is a string that references an already
-                          created Quobyte volume by name.
+                        description: Volume is a string that references an already created Quobyte volume by name.
                         type: string
                     required:
                     - registry
                     - volume
                     type: object
                   rbd:
-                    description: 'RBD represents a Rados Block Device mount on the
-                      host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                    description: 'RBD represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
                     properties:
                       fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                          TODO: how do we prevent errors in the filesystem from compromising
-                          the machine'
+                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine'
                         type: string
                       image:
                         description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                         type: string
                       keyring:
-                        description: 'Keyring is the path to key ring for RBDUser.
-                          Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        description: 'Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                         type: string
                       monitors:
                         description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
@@ -2344,80 +1618,61 @@ spec:
                           type: string
                         type: array
                       pool:
-                        description: 'The rados pool name. Default is rbd. More info:
-                          https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        description: 'The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                         type: string
                       readOnly:
-                        description: 'ReadOnly here will force the ReadOnly setting
-                          in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                         type: boolean
                       secretRef:
-                        description: 'SecretRef is name of the authentication secret
-                          for RBDUser. If provided overrides keyring. Default is nil.
-                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        description: 'SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                         properties:
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                       user:
-                        description: 'The rados user name. Default is admin. More
-                          info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        description: 'The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                         type: string
                     required:
                     - image
                     - monitors
                     type: object
                   scaleIO:
-                    description: ScaleIO represents a ScaleIO persistent volume attached
-                      and mounted on Kubernetes nodes.
+                    description: ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
                     properties:
                       fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Default is "xfs".
+                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
                         type: string
                       gateway:
                         description: The host address of the ScaleIO API Gateway.
                         type: string
                       protectionDomain:
-                        description: The name of the ScaleIO Protection Domain for
-                          the configured storage.
+                        description: The name of the ScaleIO Protection Domain for the configured storage.
                         type: string
                       readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
+                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                         type: boolean
                       secretRef:
-                        description: SecretRef references to the secret for ScaleIO
-                          user and other sensitive information. If this is not provided,
-                          Login operation will fail.
+                        description: SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
                         properties:
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                       sslEnabled:
-                        description: Flag to enable/disable SSL communication with
-                          Gateway, default false
+                        description: Flag to enable/disable SSL communication with Gateway, default false
                         type: boolean
                       storageMode:
-                        description: Indicates whether the storage for a volume should
-                          be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                        description: Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
                         type: string
                       storagePool:
-                        description: The ScaleIO Storage Pool associated with the
-                          protection domain.
+                        description: The ScaleIO Storage Pool associated with the protection domain.
                         type: string
                       system:
-                        description: The name of the storage system as configured
-                          in ScaleIO.
+                        description: The name of the storage system as configured in ScaleIO.
                         type: string
                       volumeName:
-                        description: The name of a volume already created in the ScaleIO
-                          system that is associated with this volume source.
+                        description: The name of a volume already created in the ScaleIO system that is associated with this volume source.
                         type: string
                     required:
                     - gateway
@@ -2425,28 +1680,14 @@ spec:
                     - system
                     type: object
                   secret:
-                    description: 'Secret represents a secret that should populate
-                      this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                    description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                     properties:
                       defaultMode:
-                        description: 'Optional: mode bits to use on created files
-                          by default. Must be a value between 0 and 0777. Defaults
-                          to 0644. Directories within the path are not affected by
-                          this setting. This might be in conflict with other options
-                          that affect the file mode, like fsGroup, and the result
-                          can be other mode bits set.'
+                        description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                         format: int32
                         type: integer
                       items:
-                        description: If unspecified, each key-value pair in the Data
-                          field of the referenced Secret will be projected into the
-                          volume as a file whose name is the key and content is the
-                          value. If specified, the listed keys will be projected into
-                          the specified paths, and unlisted keys will not be present.
-                          If a key is specified which is not present in the Secret,
-                          the volume setup will error unless it is marked optional.
-                          Paths must be relative and may not contain the '..' path
-                          or start with '..'.
+                        description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                         items:
                           description: Maps a string key to a path within a volume.
                           properties:
@@ -2454,19 +1695,11 @@ spec:
                               description: The key to project.
                               type: string
                             mode:
-                              description: 'Optional: mode bits to use on this file,
-                                must be a value between 0 and 0777. If not specified,
-                                the volume defaultMode will be used. This might be
-                                in conflict with other options that affect the file
-                                mode, like fsGroup, and the result can be other mode
-                                bits set.'
+                              description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                               format: int32
                               type: integer
                             path:
-                              description: The relative path of the file to map the
-                                key to. May not be an absolute path. May not contain
-                                the path element '..'. May not start with the string
-                                '..'.
+                              description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                               type: string
                           required:
                           - key
@@ -2474,69 +1707,46 @@ spec:
                           type: object
                         type: array
                       optional:
-                        description: Specify whether the Secret or its keys must be
-                          defined
+                        description: Specify whether the Secret or its keys must be defined
                         type: boolean
                       secretName:
-                        description: 'Name of the secret in the pod''s namespace to
-                          use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                        description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                         type: string
                     type: object
                   storageos:
-                    description: StorageOS represents a StorageOS volume attached
-                      and mounted on Kubernetes nodes.
+                    description: StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
                     properties:
                       fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                         type: string
                       readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
+                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                         type: boolean
                       secretRef:
-                        description: SecretRef specifies the secret to use for obtaining
-                          the StorageOS API credentials.  If not specified, default
-                          values will be attempted.
+                        description: SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
                         properties:
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                       volumeName:
-                        description: VolumeName is the human-readable name of the
-                          StorageOS volume.  Volume names are only unique within a
-                          namespace.
+                        description: VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
                         type: string
                       volumeNamespace:
-                        description: VolumeNamespace specifies the scope of the volume
-                          within StorageOS.  If no namespace is specified then the
-                          Pod's namespace will be used.  This allows the Kubernetes
-                          name scoping to be mirrored within StorageOS for tighter
-                          integration. Set VolumeName to any name to override the
-                          default behaviour. Set to "default" if you are not using
-                          namespaces within StorageOS. Namespaces that do not pre-exist
-                          within StorageOS will be created.
+                        description: VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
                         type: string
                     type: object
                   vsphereVolume:
-                    description: VsphereVolume represents a vSphere volume attached
-                      and mounted on kubelets host machine
+                    description: VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
                     properties:
                       fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                         type: string
                       storagePolicyID:
-                        description: Storage Policy Based Management (SPBM) profile
-                          ID associated with the StoragePolicyName.
+                        description: Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
                         type: string
                       storagePolicyName:
-                        description: Storage Policy Based Management (SPBM) profile
-                          name.
+                        description: Storage Policy Based Management (SPBM) profile name.
                         type: string
                       volumePath:
                         description: Path that identifies vSphere volume vmdk
@@ -2555,8 +1765,7 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: 'Limits describes the maximum amount of compute resources
-                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                     type: object
                   requests:
                     additionalProperties:
@@ -2565,10 +1774,7 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: 'Requests describes the minimum amount of compute
-                      resources required. If Requests is omitted for a container,
-                      it defaults to Limits if that is explicitly specified, otherwise
-                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                     type: object
                 type: object
               runtimeClassName:
@@ -2582,40 +1788,23 @@ spec:
               tolerations:
                 description: Tolerations
                 items:
-                  description: The pod this Toleration is attached to tolerates any
-                    taint that matches the triple <key,value,effect> using the matching
-                    operator <operator>.
+                  description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
                   properties:
                     effect:
-                      description: Effect indicates the taint effect to match. Empty
-                        means match all taint effects. When specified, allowed values
-                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                       type: string
                     key:
-                      description: Key is the taint key that the toleration applies
-                        to. Empty means match all taint keys. If the key is empty,
-                        operator must be Exists; this combination means to match all
-                        values and all keys.
+                      description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                       type: string
                     operator:
-                      description: Operator represents a key's relationship to the
-                        value. Valid operators are Exists and Equal. Defaults to Equal.
-                        Exists is equivalent to wildcard for value, so that a pod
-                        can tolerate all taints of a particular category.
+                      description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
                       type: string
                     tolerationSeconds:
-                      description: TolerationSeconds represents the period of time
-                        the toleration (which must be of effect NoExecute, otherwise
-                        this field is ignored) tolerates the taint. By default, it
-                        is not set, which means tolerate the taint forever (do not
-                        evict). Zero and negative values will be treated as 0 (evict
-                        immediately) by the system.
+                      description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
                       format: int64
                       type: integer
                     value:
-                      description: Value is the taint value the toleration matches
-                        to. If the operator is Exists, the value should be empty,
-                        otherwise just a regular string.
+                      description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                       type: string
                   type: object
                 type: array
@@ -2654,14 +1843,10 @@ spec:
         description: Input is the Schema for the inputs API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -2669,8 +1854,7 @@ spec:
             description: InputSpec defines the desired state of Input
             properties:
               alias:
-                description: A user friendly alias name for this input plugin. Used
-                  in metrics for distinction of each configured input.
+                description: A user friendly alias name for this input plugin. Used in metrics for distinction of each configured input.
                 type: string
               dummy:
                 description: Dummy defines Dummy Input configuration.
@@ -2687,23 +1871,17 @@ spec:
                     format: int32
                     type: integer
                   tag:
-                    description: Tag name associated to all records comming from this
-                      plugin.
+                    description: Tag name associated to all records comming from this plugin.
                     type: string
                 type: object
               systemd:
                 description: Systemd defines Systemd Input configuration.
                 properties:
                   db:
-                    description: Specify the database file to keep track of monitored
-                      files and offsets.
+                    description: Specify the database file to keep track of monitored files and offsets.
                     type: string
                   dbSync:
-                    description: 'Set a default synchronization (I/O) method. values:
-                      Extra, Full, Normal, Off. This flag affects how the internal
-                      SQLite engine do synchronization to disk, for more details about
-                      each option please refer to this section. note: this option
-                      was introduced on Fluent Bit v1.4.6.'
+                    description: 'Set a default synchronization (I/O) method. values: Extra, Full, Normal, Off. This flag affects how the internal SQLite engine do synchronization to disk, for more details about each option please refer to this section. note: this option was introduced on Fluent Bit v1.4.6.'
                     enum:
                     - Extra
                     - Full
@@ -2711,86 +1889,57 @@ spec:
                     - "Off"
                     type: string
                   maxEntries:
-                    description: When Fluent Bit starts, the Journal might have a
-                      high number of logs in the queue. In order to avoid delays and
-                      reduce memory usage, this option allows to specify the maximum
-                      number of log entries that can be processed per round. Once
-                      the limit is reached, Fluent Bit will continue processing the
-                      remaining log entries once Journald performs the notification.
+                    description: When Fluent Bit starts, the Journal might have a high number of logs in the queue. In order to avoid delays and reduce memory usage, this option allows to specify the maximum number of log entries that can be processed per round. Once the limit is reached, Fluent Bit will continue processing the remaining log entries once Journald performs the notification.
                     type: integer
                   maxFields:
-                    description: Set a maximum number of fields (keys) allowed per
-                      record.
+                    description: Set a maximum number of fields (keys) allowed per record.
                     type: integer
                   path:
-                    description: Optional path to the Systemd journal directory, if
-                      not set, the plugin will use default paths to read local-only
-                      logs.
+                    description: Optional path to the Systemd journal directory, if not set, the plugin will use default paths to read local-only logs.
                     type: string
                   readFromTail:
-                    description: Start reading new entries. Skip entries already stored
-                      in Journald.
+                    description: Start reading new entries. Skip entries already stored in Journald.
                     enum:
                     - "on"
                     - "off"
                     type: string
                   stripUnderscores:
-                    description: Remove the leading underscore of the Journald field
-                      (key). For example the Journald field _PID becomes the key PID.
+                    description: Remove the leading underscore of the Journald field (key). For example the Journald field _PID becomes the key PID.
                     enum:
                     - "on"
                     - "off"
                     type: string
                   systemdFilter:
-                    description: 'Allows to perform a query over logs that contains
-                      a specific Journald key/value pairs, e.g: _SYSTEMD_UNIT=UNIT.
-                      The Systemd_Filter option can be specified multiple times in
-                      the input section to apply multiple filters as required.'
+                    description: 'Allows to perform a query over logs that contains a specific Journald key/value pairs, e.g: _SYSTEMD_UNIT=UNIT. The Systemd_Filter option can be specified multiple times in the input section to apply multiple filters as required.'
                     items:
                       type: string
                     type: array
                   systemdFilterType:
-                    description: Define the filter type when Systemd_Filter is specified
-                      multiple times. Allowed values are And and Or. With And a record
-                      is matched only when all of the Systemd_Filter have a match.
-                      With Or a record is matched when any of the Systemd_Filter has
-                      a match.
+                    description: Define the filter type when Systemd_Filter is specified multiple times. Allowed values are And and Or. With And a record is matched only when all of the Systemd_Filter have a match. With Or a record is matched when any of the Systemd_Filter has a match.
                     enum:
                     - And
                     - Or
                     type: string
                   tag:
-                    description: 'The tag is used to route messages but on Systemd
-                      plugin there is an extra functionality: if the tag includes
-                      a star/wildcard, it will be expanded with the Systemd Unit file
-                      (e.g: host.* => host.UNIT_NAME).'
+                    description: 'The tag is used to route messages but on Systemd plugin there is an extra functionality: if the tag includes a star/wildcard, it will be expanded with the Systemd Unit file (e.g: host.* => host.UNIT_NAME).'
                     type: string
                 type: object
               tail:
                 description: Tail defines Tail Input configuration.
                 properties:
                   bufferChunkSize:
-                    description: Set the initial buffer size to read files data. This
-                      value is used too to increase buffer size. The value must be
-                      according to the Unit Size specification.
+                    description: Set the initial buffer size to read files data. This value is used too to increase buffer size. The value must be according to the Unit Size specification.
                     pattern: ^\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$
                     type: string
                   bufferMaxSize:
-                    description: 'Set the limit of the buffer size per monitored file.
-                      When a buffer needs to be increased (e.g: very long lines),
-                      this value is used to restrict how much the memory buffer can
-                      grow. If reading a file exceed this limit, the file is removed
-                      from the monitored file list The value must be according to
-                      the Unit Size specification.'
+                    description: 'Set the limit of the buffer size per monitored file. When a buffer needs to be increased (e.g: very long lines), this value is used to restrict how much the memory buffer can grow. If reading a file exceed this limit, the file is removed from the monitored file list The value must be according to the Unit Size specification.'
                     pattern: ^\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$
                     type: string
                   db:
-                    description: Specify the database file to keep track of monitored
-                      files and offsets.
+                    description: Specify the database file to keep track of monitored files and offsets.
                     type: string
                   dbSync:
-                    description: 'Set a default synchronization (I/O) method. Values:
-                      Extra, Full, Normal, Off.'
+                    description: 'Set a default synchronization (I/O) method. Values: Extra, Full, Normal, Off.'
                     enum:
                     - Extra
                     - Full
@@ -2798,97 +1947,65 @@ spec:
                     - "Off"
                     type: string
                   disableInotifyWatcher:
-                    description: DisableInotifyWatcher will disable inotify and use
-                      the file stat watcher instead.
+                    description: DisableInotifyWatcher will disable inotify and use the file stat watcher instead.
                     type: boolean
                   dockerMode:
-                    description: If enabled, the plugin will recombine split Docker
-                      log lines before passing them to any parser as configured above.
-                      This mode cannot be used at the same time as Multiline.
+                    description: If enabled, the plugin will recombine split Docker log lines before passing them to any parser as configured above. This mode cannot be used at the same time as Multiline.
                     type: boolean
                   dockerModeFlushSeconds:
-                    description: Wait period time in seconds to flush queued unfinished
-                      split lines.
+                    description: Wait period time in seconds to flush queued unfinished split lines.
                     format: int64
                     type: integer
                   excludePath:
-                    description: 'Set one or multiple shell patterns separated by
-                      commas to exclude files matching a certain criteria, e.g: exclude_path=*.gz,*.zip'
+                    description: 'Set one or multiple shell patterns separated by commas to exclude files matching a certain criteria, e.g: exclude_path=*.gz,*.zip'
                     type: string
                   ignoredOlder:
-                    description: Ignores records which are older than this time in
-                      seconds. Supports m,h,d (minutes, hours, days) syntax. Default
-                      behavior is to read all records from specified files. Only available
-                      when a Parser is specificied and it can parse the time of a
-                      record.
+                    description: Ignores records which are older than this time in seconds. Supports m,h,d (minutes, hours, days) syntax. Default behavior is to read all records from specified files. Only available when a Parser is specificied and it can parse the time of a record.
                     pattern: ^\d+(m|h|d)?$
                     type: string
                   key:
-                    description: When a message is unstructured (no parser applied),
-                      it's appended as a string under the key name log. This option
-                      allows to define an alternative name for that key.
+                    description: When a message is unstructured (no parser applied), it's appended as a string under the key name log. This option allows to define an alternative name for that key.
                     type: string
                   memBufLimit:
-                    description: Set a limit of memory that Tail plugin can use when
-                      appending data to the Engine. If the limit is reach, it will
-                      be paused; when the data is flushed it resumes.
+                    description: Set a limit of memory that Tail plugin can use when appending data to the Engine. If the limit is reach, it will be paused; when the data is flushed it resumes.
                     type: string
                   multiline:
-                    description: If enabled, the plugin will try to discover multiline
-                      messages and use the proper parsers to compose the outgoing
-                      messages. Note that when this option is enabled the Parser option
-                      is not used.
+                    description: If enabled, the plugin will try to discover multiline messages and use the proper parsers to compose the outgoing messages. Note that when this option is enabled the Parser option is not used.
                     type: boolean
                   multilineFlushSeconds:
-                    description: Wait period time in seconds to process queued multiline
-                      messages
+                    description: Wait period time in seconds to process queued multiline messages
                     format: int64
                     type: integer
                   parser:
-                    description: Specify the name of a parser to interpret the entry
-                      as a structured message.
+                    description: Specify the name of a parser to interpret the entry as a structured message.
                     type: string
                   parserFirstline:
-                    description: Name of the parser that matchs the beginning of a
-                      multiline message. Note that the regular expression defined
-                      in the parser must include a group name (named capture)
+                    description: Name of the parser that matchs the beginning of a multiline message. Note that the regular expression defined in the parser must include a group name (named capture)
                     type: string
                   parserN:
-                    description: Optional-extra parser to interpret and structure
-                      multiline entries. This option can be used to define multiple
-                      parsers.
+                    description: Optional-extra parser to interpret and structure multiline entries. This option can be used to define multiple parsers.
                     items:
                       type: string
                     type: array
                   path:
-                    description: Pattern specifying a specific log files or multiple
-                      ones through the use of common wildcards.
+                    description: Pattern specifying a specific log files or multiple ones through the use of common wildcards.
                     type: string
                   pathKey:
-                    description: If enabled, it appends the name of the monitored
-                      file as part of the record. The value assigned becomes the key
-                      in the map.
+                    description: If enabled, it appends the name of the monitored file as part of the record. The value assigned becomes the key in the map.
                     type: string
                   refreshIntervalSeconds:
-                    description: The interval of refreshing the list of watched files
-                      in seconds.
+                    description: The interval of refreshing the list of watched files in seconds.
                     format: int64
                     type: integer
                   rotateWaitSeconds:
-                    description: Specify the number of extra time in seconds to monitor
-                      a file once is rotated in case some pending data is flushed.
+                    description: Specify the number of extra time in seconds to monitor a file once is rotated in case some pending data is flushed.
                     format: int64
                     type: integer
                   skipLongLines:
-                    description: When a monitored file reach it buffer capacity due
-                      to a very long line (Buffer_Max_Size), the default behavior
-                      is to stop monitoring that file. Skip_Long_Lines alter that
-                      behavior and instruct Fluent Bit to skip long lines and continue
-                      processing other lines that fits into the buffer size.
+                    description: When a monitored file reach it buffer capacity due to a very long line (Buffer_Max_Size), the default behavior is to stop monitoring that file. Skip_Long_Lines alter that behavior and instruct Fluent Bit to skip long lines and continue processing other lines that fits into the buffer size.
                     type: boolean
                   tag:
-                    description: Set a tag (with regex-extract fields) that will be
-                      placed on lines read. E.g. kube.<namespace_name>.<pod_name>.<container_name>
+                    description: Set a tag (with regex-extract fields) that will be placed on lines read. E.g. kube.<namespace_name>.<pod_name>.<container_name>
                     type: string
                   tagRegex:
                     description: Set a regex to exctract fields from the file
@@ -2926,14 +2043,10 @@ spec:
         description: Output is the Schema for the outputs API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -2941,56 +2054,62 @@ spec:
             description: OutputSpec defines the desired state of Output
             properties:
               alias:
-                description: A user friendly alias name for this output plugin. Used
-                  in metrics for distinction of each configured output.
+                description: A user friendly alias name for this output plugin. Used in metrics for distinction of each configured output.
                 type: string
               es:
                 description: Elasticsearch defines Elasticsearch Output configuration.
                 properties:
+                  awsAuth:
+                    description: Enable AWS Sigv4 Authentication for Amazon ElasticSearch Service.
+                    type: string
+                  awsExternalID:
+                    description: External ID for the AWS IAM Role specified with aws_role_arn.
+                    type: string
+                  awsRegion:
+                    description: Specify the AWS region for Amazon ElasticSearch Service.
+                    type: string
+                  awsRoleARN:
+                    description: AWS IAM Role to assume to put records to your Amazon ES cluster.
+                    type: string
+                  awsSTSEndpoint:
+                    description: Specify the custom sts endpoint to be used with STS API for Amazon ElasticSearch Service.
+                    type: string
                   bufferSize:
-                    description: Specify the buffer size used to read the response
-                      from the Elasticsearch HTTP service. This option is useful for
-                      debugging purposes where is required to read full responses,
-                      note that response size grows depending of the number of records
-                      inserted. To set an unlimited amount of memory set this value
-                      to False, otherwise the value must be according to the Unit
-                      Size specification.
+                    description: Specify the buffer size used to read the response from the Elasticsearch HTTP service. This option is useful for debugging purposes where is required to read full responses, note that response size grows depending of the number of records inserted. To set an unlimited amount of memory set this value to False, otherwise the value must be according to the Unit Size specification.
                     pattern: ^\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$
                     type: string
+                  cloudAuth:
+                    description: Specify the credentials to use to connect to Elastic's Elasticsearch Service running on Elastic Cloud.
+                    type: string
+                  cloudID:
+                    description: If you are using Elastic's Elasticsearch Service you can specify the cloud_id of the cluster running.
+                    type: string
                   currentTimeIndex:
-                    description: Use current time for index generation instead of
-                      message record
+                    description: Use current time for index generation instead of message record
                     type: boolean
                   generateID:
-                    description: When enabled, generate _id for outgoing records.
-                      This prevents duplicate records when retrying ES.
+                    description: When enabled, generate _id for outgoing records. This prevents duplicate records when retrying ES.
                     type: boolean
                   host:
-                    description: IP address or hostname of the target Elasticsearch
-                      instance
+                    description: IP address or hostname of the target Elasticsearch instance
                     type: string
                   httpPassword:
                     description: Password for user defined in HTTP_User
                     properties:
                       valueFrom:
-                        description: ValueSource represents a source for the value
-                          of a secret.
+                        description: ValueSource represents a source for the value of a secret.
                         properties:
                           secretKeyRef:
                             description: Selects a key of a secret in the pod's namespace
                             properties:
                               key:
-                                description: The key of the secret to select from.  Must
-                                  be a valid secret key.
+                                description: The key of the secret to select from.  Must be a valid secret key.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
                               optional:
-                                description: Specify whether the Secret or its key
-                                  must be defined
+                                description: Specify whether the Secret or its key must be defined
                                 type: boolean
                             required:
                             - key
@@ -3001,30 +2120,28 @@ spec:
                     description: Optional username credential for Elastic X-Pack access
                     properties:
                       valueFrom:
-                        description: ValueSource represents a source for the value
-                          of a secret.
+                        description: ValueSource represents a source for the value of a secret.
                         properties:
                           secretKeyRef:
                             description: Selects a key of a secret in the pod's namespace
                             properties:
                               key:
-                                description: The key of the secret to select from.  Must
-                                  be a valid secret key.
+                                description: The key of the secret to select from.  Must be a valid secret key.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
                               optional:
-                                description: Specify whether the Secret or its key
-                                  must be defined
+                                description: Specify whether the Secret or its key must be defined
                                 type: boolean
                             required:
                             - key
                             type: object
                         type: object
                     type: object
+                  idKey:
+                    description: If set, _id will be the value of the key from incoming record and Generate_ID option is ignored.
+                    type: string
                   includeTagKey:
                     description: When enabled, it append the Tag name to the record.
                     type: boolean
@@ -3032,36 +2149,22 @@ spec:
                     description: Index name
                     type: string
                   logstashDateFormat:
-                    description: Time format (based on strftime) to generate the second
-                      part of the Index name.
+                    description: Time format (based on strftime) to generate the second part of the Index name.
                     type: string
                   logstashFormat:
-                    description: 'Enable Logstash format compatibility. This option
-                      takes a boolean value: True/False, On/Off'
+                    description: 'Enable Logstash format compatibility. This option takes a boolean value: True/False, On/Off'
                     type: boolean
                   logstashPrefix:
-                    description: 'When Logstash_Format is enabled, the Index name
-                      is composed using a prefix and the date, e.g: If Logstash_Prefix
-                      is equals to ''mydata'' your index will become ''mydata-YYYY.MM.DD''.
-                      The last string appended belongs to the date when the data is
-                      being generated.'
+                    description: 'When Logstash_Format is enabled, the Index name is composed using a prefix and the date, e.g: If Logstash_Prefix is equals to ''mydata'' your index will become ''mydata-YYYY.MM.DD''. The last string appended belongs to the date when the data is being generated.'
                     type: string
                   logstashPrefixKey:
                     description: Prefix keys with this string
                     type: string
                   path:
-                    description: Elasticsearch accepts new data on HTTP query path
-                      "/_bulk". But it is also possible to serve Elasticsearch behind
-                      a reverse proxy on a subpath. This option defines such path
-                      on the fluent-bit side. It simply adds a path prefix in the
-                      indexing HTTP POST URI.
+                    description: Elasticsearch accepts new data on HTTP query path "/_bulk". But it is also possible to serve Elasticsearch behind a reverse proxy on a subpath. This option defines such path on the fluent-bit side. It simply adds a path prefix in the indexing HTTP POST URI.
                     type: string
                   pipeline:
-                    description: Newer versions of Elasticsearch allows to setup filters
-                      called pipelines. This option allows to define which pipeline
-                      the database should use. For performance reasons is strongly
-                      suggested to do parsing and filtering on Fluent Bit side, avoid
-                      pipelines.
+                    description: Newer versions of Elasticsearch allows setting up filters called pipelines. This option allows defining which pipeline the database should use. For performance reasons is strongly suggested parsing and filtering on Fluent Bit side, avoid pipelines.
                     type: string
                   port:
                     description: TCP port of the target Elasticsearch instance
@@ -3070,26 +2173,22 @@ spec:
                     minimum: 1
                     type: integer
                   replaceDots:
-                    description: When enabled, replace field name dots with underscore,
-                      required by Elasticsearch 2.0-2.3.
+                    description: When enabled, replace field name dots with underscore, required by Elasticsearch 2.0-2.3.
                     type: boolean
+                  suppressTypeName:
+                    description: When enabled, mapping types is removed and Type option is ignored. Types are deprecated in APIs in v7.0. This options is for v7.0 or later.
+                    type: string
                   tagKey:
-                    description: When Include_Tag_Key is enabled, this property defines
-                      the key name for the tag.
+                    description: When Include_Tag_Key is enabled, this property defines the key name for the tag.
                     type: string
                   timeKey:
-                    description: When Logstash_Format is enabled, each record will
-                      get a new timestamp field. The Time_Key property defines the
-                      name of that field.
+                    description: When Logstash_Format is enabled, each record will get a new timestamp field. The Time_Key property defines the name of that field.
                     type: string
                   timeKeyFormat:
-                    description: When Logstash_Format is enabled, this property defines
-                      the format of the timestamp.
+                    description: When Logstash_Format is enabled, this property defines the format of the timestamp.
                     type: string
                   tls:
-                    description: Fluent Bit provides integrated support for Transport
-                      Layer Security (TLS) and it predecessor Secure Sockets Layer
-                      (SSL) respectively.
+                    description: Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.
                     properties:
                       caFile:
                         description: Absolute path to CA certificate file
@@ -3101,9 +2200,7 @@ spec:
                         description: Absolute path to Certificate file
                         type: string
                       debug:
-                        description: 'Set TLS debug verbosity level. It accept the
-                          following values: 0 (No debug), 1 (Error), 2 (State change),
-                          3 (Informational) and 4 Verbose'
+                        description: 'Set TLS debug verbosity level. It accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose'
                         enum:
                         - 0
                         - 1
@@ -3119,26 +2216,19 @@ spec:
                         description: Optional password for tls.key_file file
                         properties:
                           valueFrom:
-                            description: ValueSource represents a source for the value
-                              of a secret.
+                            description: ValueSource represents a source for the value of a secret.
                             properties:
                               secretKeyRef:
-                                description: Selects a key of a secret in the pod's
-                                  namespace
+                                description: Selects a key of a secret in the pod's namespace
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.  Must
-                                      be a valid secret key.
+                                    description: The key of the secret to select from.  Must be a valid secret key.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the Secret or its
-                                      key must be defined
+                                    description: Specify whether the Secret or its key must be defined
                                     type: boolean
                                 required:
                                 - key
@@ -3153,12 +2243,10 @@ spec:
                         type: string
                     type: object
                   traceError:
-                    description: When enabled print the elasticsearch API calls to
-                      stdout when elasticsearch returns an error
+                    description: When enabled print the elasticsearch API calls to stdout when elasticsearch returns an error
                     type: boolean
                   traceOutput:
-                    description: When enabled print the elasticsearch API calls to
-                      stdout (for diag only)
+                    description: When enabled print the elasticsearch API calls to stdout (for diag only)
                     type: boolean
                   type:
                     description: Type name
@@ -3168,16 +2256,13 @@ spec:
                 description: File defines File Output configuration.
                 properties:
                   delimiter:
-                    description: The character to separate each pair. Applicable only
-                      if format is csv or ltsv.
+                    description: The character to separate each pair. Applicable only if format is csv or ltsv.
                     type: string
                   file:
-                    description: Set file name to store the records. If not set, the
-                      file name will be the tag associated with the records.
+                    description: Set file name to store the records. If not set, the file name will be the tag associated with the records.
                     type: string
                   format:
-                    description: 'The format of the file content. See also Format
-                      section. Default: out_file.'
+                    description: 'The format of the file content. See also Format section. Default: out_file.'
                     enum:
                     - out_file
                     - plain
@@ -3186,12 +2271,10 @@ spec:
                     - template
                     type: string
                   labelDelimiter:
-                    description: The character to separate each pair. Applicable only
-                      if format is ltsv.
+                    description: The character to separate each pair. Applicable only if format is ltsv.
                     type: string
                   path:
-                    description: Absolute directory path to store files. If not set,
-                      Fluent Bit will write the files on it's own positioned directory.
+                    description: Absolute directory path to store files. If not set, Fluent Bit will write the files on it's own positioned directory.
                     type: string
                   template:
                     description: The format string. Applicable only if format is template.
@@ -3201,35 +2284,28 @@ spec:
                 description: Forward defines Forward Output configuration.
                 properties:
                   emptySharedKey:
-                    description: Use this option to connect to Fluentd with a zero-length
-                      secret.
+                    description: Use this option to connect to Fluentd with a zero-length secret.
                     type: boolean
                   host:
-                    description: Target host where Fluent-Bit or Fluentd are listening
-                      for Forward messages.
+                    description: Target host where Fluent-Bit or Fluentd are listening for Forward messages.
                     type: string
                   password:
                     description: Specify the password corresponding to the username.
                     properties:
                       valueFrom:
-                        description: ValueSource represents a source for the value
-                          of a secret.
+                        description: ValueSource represents a source for the value of a secret.
                         properties:
                           secretKeyRef:
                             description: Selects a key of a secret in the pod's namespace
                             properties:
                               key:
-                                description: The key of the secret to select from.  Must
-                                  be a valid secret key.
+                                description: The key of the secret to select from.  Must be a valid secret key.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
                               optional:
-                                description: Specify whether the Secret or its key
-                                  must be defined
+                                description: Specify whether the Secret or its key must be defined
                                 type: boolean
                             required:
                             - key
@@ -3243,29 +2319,22 @@ spec:
                     minimum: 1
                     type: integer
                   requireAckResponse:
-                    description: Send "chunk"-option and wait for "ack" response from
-                      server. Enables at-least-once and receiving server can control
-                      rate of traffic. (Requires Fluentd v0.14.0+ server)
+                    description: Send "chunk"-option and wait for "ack" response from server. Enables at-least-once and receiving server can control rate of traffic. (Requires Fluentd v0.14.0+ server)
                     type: boolean
                   selfHostname:
-                    description: Default value of the auto-generated certificate common
-                      name (CN).
+                    description: Default value of the auto-generated certificate common name (CN).
                     type: string
                   sendOptions:
                     description: Always send options (with "size"=count of messages)
                     type: boolean
                   sharedKey:
-                    description: A key string known by the remote Fluentd used for
-                      authorization.
+                    description: A key string known by the remote Fluentd used for authorization.
                     type: string
                   timeAsInteger:
-                    description: Set timestamps in integer format, it enable compatibility
-                      mode for Fluentd v0.12 series.
+                    description: Set timestamps in integer format, it enable compatibility mode for Fluentd v0.12 series.
                     type: boolean
                   tls:
-                    description: Fluent Bit provides integrated support for Transport
-                      Layer Security (TLS) and it predecessor Secure Sockets Layer
-                      (SSL) respectively.
+                    description: Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.
                     properties:
                       caFile:
                         description: Absolute path to CA certificate file
@@ -3277,9 +2346,7 @@ spec:
                         description: Absolute path to Certificate file
                         type: string
                       debug:
-                        description: 'Set TLS debug verbosity level. It accept the
-                          following values: 0 (No debug), 1 (Error), 2 (State change),
-                          3 (Informational) and 4 Verbose'
+                        description: 'Set TLS debug verbosity level. It accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose'
                         enum:
                         - 0
                         - 1
@@ -3295,26 +2362,19 @@ spec:
                         description: Optional password for tls.key_file file
                         properties:
                           valueFrom:
-                            description: ValueSource represents a source for the value
-                              of a secret.
+                            description: ValueSource represents a source for the value of a secret.
                             properties:
                               secretKeyRef:
-                                description: Selects a key of a secret in the pod's
-                                  namespace
+                                description: Selects a key of a secret in the pod's namespace
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.  Must
-                                      be a valid secret key.
+                                    description: The key of the secret to select from.  Must be a valid secret key.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the Secret or its
-                                      key must be defined
+                                    description: Specify whether the Secret or its key must be defined
                                     type: boolean
                                 required:
                                 - key
@@ -3329,28 +2389,22 @@ spec:
                         type: string
                     type: object
                   username:
-                    description: Specify the username to present to a Fluentd server
-                      that enables user_auth.
+                    description: Specify the username to present to a Fluentd server that enables user_auth.
                     properties:
                       valueFrom:
-                        description: ValueSource represents a source for the value
-                          of a secret.
+                        description: ValueSource represents a source for the value of a secret.
                         properties:
                           secretKeyRef:
                             description: Selects a key of a secret in the pod's namespace
                             properties:
                               key:
-                                description: The key of the secret to select from.  Must
-                                  be a valid secret key.
+                                description: The key of the secret to select from.  Must be a valid secret key.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
                               optional:
-                                description: Specify whether the Secret or its key
-                                  must be defined
+                                description: Specify whether the Secret or its key must be defined
                                 type: boolean
                             required:
                             - key
@@ -3362,17 +2416,13 @@ spec:
                 description: HTTP defines HTTP Output configuration.
                 properties:
                   allowDuplicatedHeaders:
-                    description: Specify if duplicated headers are allowed. If a duplicated
-                      header is found, the latest key/value set is preserved.
+                    description: Specify if duplicated headers are allowed. If a duplicated header is found, the latest key/value set is preserved.
                     type: boolean
                   compress:
-                    description: Set payload compression mechanism. Option available
-                      is 'gzip'
+                    description: Set payload compression mechanism. Option available is 'gzip'
                     type: string
                   format:
-                    description: Specify the data format to be used in the HTTP request
-                      body, by default it uses msgpack. Other supported formats are
-                      json, json_stream and json_lines and gelf.
+                    description: Specify the data format to be used in the HTTP request body, by default it uses msgpack. Other supported formats are json, json_stream and json_lines and gelf.
                     enum:
                     - msgpack
                     - json
@@ -3381,8 +2431,7 @@ spec:
                     - gelf
                     type: string
                   gelfFullMessageKey:
-                    description: Specify the key to use for the full message in gelf
-                      format
+                    description: Specify the key to use for the full message in gelf format
                     type: string
                   gelfHostKey:
                     description: Specify the key to use for the host in gelf format
@@ -3391,21 +2440,18 @@ spec:
                     description: Specify the key to use for the level in gelf format
                     type: string
                   gelfShortMessgeKey:
-                    description: Specify the key to use as the short message in gelf
-                      format
+                    description: Specify the key to use as the short message in gelf format
                     type: string
                   gelfTimestampKey:
                     description: Specify the key to use for timestamp in gelf format
                     type: string
                   headerTag:
-                    description: Specify an optional HTTP header field for the original
-                      message tag.
+                    description: Specify an optional HTTP header field for the original message tag.
                     type: string
                   headers:
                     additionalProperties:
                       type: string
-                    description: Add a HTTP header key/value pair. Multiple headers
-                      can be set.
+                    description: Add a HTTP header key/value pair. Multiple headers can be set.
                     type: object
                   host:
                     description: IP address or hostname of the target HTTP Server
@@ -3414,24 +2460,19 @@ spec:
                     description: Basic Auth Password. Requires HTTP_User to be set
                     properties:
                       valueFrom:
-                        description: ValueSource represents a source for the value
-                          of a secret.
+                        description: ValueSource represents a source for the value of a secret.
                         properties:
                           secretKeyRef:
                             description: Selects a key of a secret in the pod's namespace
                             properties:
                               key:
-                                description: The key of the secret to select from.  Must
-                                  be a valid secret key.
+                                description: The key of the secret to select from.  Must be a valid secret key.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
                               optional:
-                                description: Specify whether the Secret or its key
-                                  must be defined
+                                description: Specify whether the Secret or its key must be defined
                                 type: boolean
                             required:
                             - key
@@ -3442,24 +2483,19 @@ spec:
                     description: Basic Auth Username
                     properties:
                       valueFrom:
-                        description: ValueSource represents a source for the value
-                          of a secret.
+                        description: ValueSource represents a source for the value of a secret.
                         properties:
                           secretKeyRef:
                             description: Selects a key of a secret in the pod's namespace
                             properties:
                               key:
-                                description: The key of the secret to select from.  Must
-                                  be a valid secret key.
+                                description: The key of the secret to select from.  Must be a valid secret key.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
                               optional:
-                                description: Specify whether the Secret or its key
-                                  must be defined
+                                description: Specify whether the Secret or its key must be defined
                                 type: boolean
                             required:
                             - key
@@ -3467,12 +2503,10 @@ spec:
                         type: object
                     type: object
                   jsonDateFormat:
-                    description: 'Specify the format of the date. Supported formats
-                      are double, epoch and iso8601 (eg: 2018-05-30T09:39:52.000681Z)'
+                    description: 'Specify the format of the date. Supported formats are double, epoch and iso8601 (eg: 2018-05-30T09:39:52.000681Z)'
                     type: string
                   jsonDateKey:
-                    description: Specify the name of the time key in the output record.
-                      To disable the time key just set the value to false.
+                    description: Specify the name of the time key in the output record. To disable the time key just set the value to false.
                     type: string
                   port:
                     description: TCP port of the target HTTP Server
@@ -3481,14 +2515,10 @@ spec:
                     minimum: 1
                     type: integer
                   proxy:
-                    description: Specify an HTTP Proxy. The expected format of this
-                      value is http://host:port. Note that https is not supported
-                      yet.
+                    description: Specify an HTTP Proxy. The expected format of this value is http://host:port. Note that https is not supported yet.
                     type: string
                   tls:
-                    description: HTTP output plugin supports TTL/SSL, for more details
-                      about the properties available and general configuration, please
-                      refer to the TLS/SSL section.
+                    description: HTTP output plugin supports TTL/SSL, for more details about the properties available and general configuration, please refer to the TLS/SSL section.
                     properties:
                       caFile:
                         description: Absolute path to CA certificate file
@@ -3500,9 +2530,7 @@ spec:
                         description: Absolute path to Certificate file
                         type: string
                       debug:
-                        description: 'Set TLS debug verbosity level. It accept the
-                          following values: 0 (No debug), 1 (Error), 2 (State change),
-                          3 (Informational) and 4 Verbose'
+                        description: 'Set TLS debug verbosity level. It accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose'
                         enum:
                         - 0
                         - 1
@@ -3518,26 +2546,19 @@ spec:
                         description: Optional password for tls.key_file file
                         properties:
                           valueFrom:
-                            description: ValueSource represents a source for the value
-                              of a secret.
+                            description: ValueSource represents a source for the value of a secret.
                             properties:
                               secretKeyRef:
-                                description: Selects a key of a secret in the pod's
-                                  namespace
+                                description: Selects a key of a secret in the pod's namespace
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.  Must
-                                      be a valid secret key.
+                                    description: The key of the secret to select from.  Must be a valid secret key.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the Secret or its
-                                      key must be defined
+                                    description: Specify whether the Secret or its key must be defined
                                     type: boolean
                                 required:
                                 - key
@@ -3552,16 +2573,14 @@ spec:
                         type: string
                     type: object
                   uri:
-                    description: 'Specify an optional HTTP URI for the target web
-                      server, e.g: /something'
+                    description: 'Specify an optional HTTP URI for the target web server, e.g: /something'
                     type: string
                 type: object
               kafka:
                 description: Kafka defines Kafka Output configuration.
                 properties:
                   brokers:
-                    description: 'Single of multiple list of Kafka Brokers, e.g: 192.168.1.3:9092,
-                      192.168.1.4:9092.'
+                    description: 'Single of multiple list of Kafka Brokers, e.g: 192.168.1.3:9092, 192.168.1.4:9092.'
                     type: string
                   format:
                     description: 'Specify data format, options available: json, msgpack.'
@@ -3570,9 +2589,7 @@ spec:
                     description: Optional key to store the message
                     type: string
                   messageKeyField:
-                    description: If set, the value of Message_Key_Field in the record
-                      will indicate the message key. If not set nor found in the record,
-                      Message_Key will be used (if set).
+                    description: If set, the value of Message_Key_Field in the record will indicate the message key. If not set nor found in the record, Message_Key will be used (if set).
                     type: string
                   rdkafka:
                     additionalProperties:
@@ -3586,27 +2603,17 @@ spec:
                     description: Set the key to store the record timestamp
                     type: string
                   topicKey:
-                    description: 'If multiple Topics exists, the value of Topic_Key
-                      in the record will indicate the topic to use. E.g: if Topic_Key
-                      is router and the record is {"key1": 123, "router": "route_2"},
-                      Fluent Bit will use topic route_2. Note that if the value of
-                      Topic_Key is not present in Topics, then by default the first
-                      topic in the Topics list will indicate the topic to be used.'
+                    description: 'If multiple Topics exists, the value of Topic_Key in the record will indicate the topic to use. E.g: if Topic_Key is router and the record is {"key1": 123, "router": "route_2"}, Fluent Bit will use topic route_2. Note that if the value of Topic_Key is not present in Topics, then by default the first topic in the Topics list will indicate the topic to be used.'
                     type: string
                   topics:
-                    description: Single entry or list of topics separated by comma
-                      (,) that Fluent Bit will use to send messages to Kafka. If only
-                      one topic is set, that one will be used for all records. Instead
-                      if multiple topics exists, the one set in the record by Topic_Key
-                      will be used.
+                    description: Single entry or list of topics separated by comma (,) that Fluent Bit will use to send messages to Kafka. If only one topic is set, that one will be used for all records. Instead if multiple topics exists, the one set in the record by Topic_Key will be used.
                     type: string
                 type: object
               loki:
                 description: Loki defines Loki Output configuration.
                 properties:
                   autoKubernetesLabels:
-                    description: If set to true, it will add all Kubernetes labels
-                      to the Stream labels.
+                    description: If set to true, it will add all Kubernetes labels to the Stream labels.
                     enum:
                     - "on"
                     - "off"
@@ -3615,28 +2622,22 @@ spec:
                     description: Loki hostname or IP address.
                     type: string
                   httpPassword:
-                    description: Password for user defined in HTTP_User Set HTTP basic
-                      authentication password
+                    description: Password for user defined in HTTP_User Set HTTP basic authentication password
                     properties:
                       valueFrom:
-                        description: ValueSource represents a source for the value
-                          of a secret.
+                        description: ValueSource represents a source for the value of a secret.
                         properties:
                           secretKeyRef:
                             description: Selects a key of a secret in the pod's namespace
                             properties:
                               key:
-                                description: The key of the secret to select from.  Must
-                                  be a valid secret key.
+                                description: The key of the secret to select from.  Must be a valid secret key.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
                               optional:
-                                description: Specify whether the Secret or its key
-                                  must be defined
+                                description: Specify whether the Secret or its key must be defined
                                 type: boolean
                             required:
                             - key
@@ -3647,24 +2648,19 @@ spec:
                     description: Set HTTP basic authentication user name.
                     properties:
                       valueFrom:
-                        description: ValueSource represents a source for the value
-                          of a secret.
+                        description: ValueSource represents a source for the value of a secret.
                         properties:
                           secretKeyRef:
                             description: Selects a key of a secret in the pod's namespace
                             properties:
                               key:
-                                description: The key of the secret to select from.  Must
-                                  be a valid secret key.
+                                description: The key of the secret to select from.  Must be a valid secret key.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
                               optional:
-                                description: Specify whether the Secret or its key
-                                  must be defined
+                                description: Specify whether the Secret or its key must be defined
                                 type: boolean
                             required:
                             - key
@@ -3672,27 +2668,17 @@ spec:
                         type: object
                     type: object
                   labelKeys:
-                    description: Optional list of record keys that will be placed
-                      as stream labels. This configuration property is for records
-                      key only.
+                    description: Optional list of record keys that will be placed as stream labels. This configuration property is for records key only.
                     items:
                       type: string
                     type: array
                   labels:
-                    description: Stream labels for API request. It can be multiple
-                      comma separated of strings specifying  key=value pairs. In addition
-                      to fixed parameters, it also allows to add custom record keys
-                      (similar to label_keys property).
+                    description: Stream labels for API request. It can be multiple comma separated of strings specifying  key=value pairs. In addition to fixed parameters, it also allows to add custom record keys (similar to label_keys property).
                     items:
                       type: string
                     type: array
                   lineFormat:
-                    description: Format to use when flattening the record to a log
-                      line. Valid values are json or key_value. If set to json,  the
-                      log line sent to Loki will be the Fluent Bit record dumped as
-                      JSON. If set to key_value, the log line will be each item in
-                      the record concatenated together (separated by a single space)
-                      in the format.
+                    description: Format to use when flattening the record to a log line. Valid values are json or key_value. If set to json,  the log line sent to Loki will be the Fluent Bit record dumped as JSON. If set to key_value, the log line will be each item in the record concatenated together (separated by a single space) in the format.
                     enum:
                     - json
                     - key_value
@@ -3704,29 +2690,22 @@ spec:
                     minimum: 1
                     type: integer
                   tenantID:
-                    description: Tenant ID used by default to push logs to Loki. If
-                      omitted or empty it assumes Loki is running in single-tenant
-                      mode and no X-Scope-OrgID header is sent.
+                    description: Tenant ID used by default to push logs to Loki. If omitted or empty it assumes Loki is running in single-tenant mode and no X-Scope-OrgID header is sent.
                     properties:
                       valueFrom:
-                        description: ValueSource represents a source for the value
-                          of a secret.
+                        description: ValueSource represents a source for the value of a secret.
                         properties:
                           secretKeyRef:
                             description: Selects a key of a secret in the pod's namespace
                             properties:
                               key:
-                                description: The key of the secret to select from.  Must
-                                  be a valid secret key.
+                                description: The key of the secret to select from.  Must be a valid secret key.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
                               optional:
-                                description: Specify whether the Secret or its key
-                                  must be defined
+                                description: Specify whether the Secret or its key must be defined
                                 type: boolean
                             required:
                             - key
@@ -3734,9 +2713,7 @@ spec:
                         type: object
                     type: object
                   tls:
-                    description: Fluent Bit provides integrated support for Transport
-                      Layer Security (TLS) and it predecessor Secure Sockets Layer
-                      (SSL) respectively.
+                    description: Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.
                     properties:
                       caFile:
                         description: Absolute path to CA certificate file
@@ -3748,9 +2725,7 @@ spec:
                         description: Absolute path to Certificate file
                         type: string
                       debug:
-                        description: 'Set TLS debug verbosity level. It accept the
-                          following values: 0 (No debug), 1 (Error), 2 (State change),
-                          3 (Informational) and 4 Verbose'
+                        description: 'Set TLS debug verbosity level. It accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose'
                         enum:
                         - 0
                         - 1
@@ -3766,26 +2741,19 @@ spec:
                         description: Optional password for tls.key_file file
                         properties:
                           valueFrom:
-                            description: ValueSource represents a source for the value
-                              of a secret.
+                            description: ValueSource represents a source for the value of a secret.
                             properties:
                               secretKeyRef:
-                                description: Selects a key of a secret in the pod's
-                                  namespace
+                                description: Selects a key of a secret in the pod's namespace
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.  Must
-                                      be a valid secret key.
+                                    description: The key of the secret to select from.  Must be a valid secret key.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the Secret or its
-                                      key must be defined
+                                    description: Specify whether the Secret or its key must be defined
                                     type: boolean
                                 required:
                                 - key
@@ -3803,12 +2771,10 @@ spec:
                 - host
                 type: object
               match:
-                description: A pattern to match against the tags of incoming records.
-                  It's case sensitive and support the star (*) character as a wildcard.
+                description: A pattern to match against the tags of incoming records. It's case sensitive and support the star (*) character as a wildcard.
                 type: string
               matchRegex:
-                description: A regular expression to match against the tags of incoming
-                  records. Use this option if you want to use the full regex syntax.
+                description: A regular expression to match against the tags of incoming records. Use this option if you want to use the full regex syntax.
                 type: string
               "null":
                 description: Null defines Null Output configuration.
@@ -3817,8 +2783,7 @@ spec:
                 description: Stdout defines Stdout Output configuration.
                 properties:
                   format:
-                    description: Specify the data format to be printed. Supported
-                      formats are msgpack json, json_lines and json_stream.
+                    description: Specify the data format to be printed. Supported formats are msgpack json, json_lines and json_stream.
                     enum:
                     - msgpack
                     - json
@@ -3826,8 +2791,7 @@ spec:
                     - json_stream
                     type: string
                   jsonDateFormat:
-                    description: 'Specify the format of the date. Supported formats
-                      are double,  iso8601 (eg: 2018-05-30T09:39:52.000681Z) and epoch.'
+                    description: 'Specify the format of the date. Supported formats are double,  iso8601 (eg: 2018-05-30T09:39:52.000681Z) and epoch.'
                     enum:
                     - double
                     - iso8601
@@ -3844,8 +2808,7 @@ spec:
                     description: Host domain or IP address of the remote Syslog server.
                     type: string
                   mode:
-                    description: Mode of the desired transport type, the available
-                      options are tcp, tls and udp.
+                    description: Mode of the desired transport type, the available options are tcp, tls and udp.
                     type: string
                   port:
                     description: TCP or UDP port of the remote Syslog server.
@@ -3854,48 +2817,38 @@ spec:
                     minimum: 1
                     type: integer
                   syslogAppnameKey:
-                    description: Key name from the original record that contains the
-                      application name that generated the message.
+                    description: Key name from the original record that contains the application name that generated the message.
                     type: string
                   syslogFacilityKey:
-                    description: Key from the original record that contains the Syslog
-                      facility number.
+                    description: Key from the original record that contains the Syslog facility number.
                     type: string
                   syslogFormat:
-                    description: Syslog protocol format to use, the available options
-                      are rfc3164 and rfc5424.
+                    description: Syslog protocol format to use, the available options are rfc3164 and rfc5424.
                     type: string
                   syslogHostnameKey:
-                    description: Key name from the original record that contains the
-                      hostname that generated the message.
+                    description: Key name from the original record that contains the hostname that generated the message.
                     type: string
                   syslogMaxSize:
                     description: Maximum size allowed per message, in bytes.
                     format: int32
                     type: integer
                   syslogMessageIDKey:
-                    description: Key name from the original record that contains the
-                      Message ID associated to the message.
+                    description: Key name from the original record that contains the Message ID associated to the message.
                     type: string
                   syslogMessageKey:
                     description: Key key name that contains the message to deliver.
                     type: string
                   syslogProcessIDKey:
-                    description: Key name from the original record that contains the
-                      Process ID that generated the message.
+                    description: Key name from the original record that contains the Process ID that generated the message.
                     type: string
                   syslogSDKey:
-                    description: Key name from the original record that contains the
-                      Structured Data (SD) content.
+                    description: Key name from the original record that contains the Structured Data (SD) content.
                     type: string
                   syslogSeverityKey:
-                    description: Key from the original record that contains the Syslog
-                      severity number.
+                    description: Key from the original record that contains the Syslog severity number.
                     type: string
                   tls:
-                    description: Syslog output plugin supports TTL/SSL, for more details
-                      about the properties available and general configuration, please
-                      refer to the TLS/SSL section.
+                    description: Syslog output plugin supports TTL/SSL, for more details about the properties available and general configuration, please refer to the TLS/SSL section.
                     properties:
                       caFile:
                         description: Absolute path to CA certificate file
@@ -3907,9 +2860,7 @@ spec:
                         description: Absolute path to Certificate file
                         type: string
                       debug:
-                        description: 'Set TLS debug verbosity level. It accept the
-                          following values: 0 (No debug), 1 (Error), 2 (State change),
-                          3 (Informational) and 4 Verbose'
+                        description: 'Set TLS debug verbosity level. It accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose'
                         enum:
                         - 0
                         - 1
@@ -3925,26 +2876,19 @@ spec:
                         description: Optional password for tls.key_file file
                         properties:
                           valueFrom:
-                            description: ValueSource represents a source for the value
-                              of a secret.
+                            description: ValueSource represents a source for the value of a secret.
                             properties:
                               secretKeyRef:
-                                description: Selects a key of a secret in the pod's
-                                  namespace
+                                description: Selects a key of a secret in the pod's namespace
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.  Must
-                                      be a valid secret key.
+                                    description: The key of the secret to select from.  Must be a valid secret key.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the Secret or its
-                                      key must be defined
+                                    description: Specify whether the Secret or its key must be defined
                                     type: boolean
                                 required:
                                 - key
@@ -3963,8 +2907,7 @@ spec:
                 description: TCP defines TCP Output configuration.
                 properties:
                   format:
-                    description: Specify the data format to be printed. Supported
-                      formats are msgpack json, json_lines and json_stream.
+                    description: Specify the data format to be printed. Supported formats are msgpack json, json_lines and json_stream.
                     enum:
                     - msgpack
                     - json
@@ -3972,20 +2915,17 @@ spec:
                     - json_stream
                     type: string
                   host:
-                    description: Target host where Fluent-Bit or Fluentd are listening
-                      for Forward messages.
+                    description: Target host where Fluent-Bit or Fluentd are listening for Forward messages.
                     type: string
                   jsonDateFormat:
-                    description: 'Specify the format of the date. Supported formats
-                      are double, epoch and iso8601 (eg: 2018-05-30T09:39:52.000681Z)'
+                    description: 'Specify the format of the date. Supported formats are double, epoch and iso8601 (eg: 2018-05-30T09:39:52.000681Z)'
                     enum:
                     - double
                     - epoch
                     - iso8601
                     type: string
                   jsonDateKey:
-                    description: TSpecify the name of the time key in the output record.
-                      To disable the time key just set the value to false.
+                    description: TSpecify the name of the time key in the output record. To disable the time key just set the value to false.
                     type: string
                   port:
                     description: TCP Port of the target service.
@@ -3994,9 +2934,7 @@ spec:
                     minimum: 1
                     type: integer
                   tls:
-                    description: Fluent Bit provides integrated support for Transport
-                      Layer Security (TLS) and it predecessor Secure Sockets Layer
-                      (SSL) respectively.
+                    description: Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.
                     properties:
                       caFile:
                         description: Absolute path to CA certificate file
@@ -4008,9 +2946,7 @@ spec:
                         description: Absolute path to Certificate file
                         type: string
                       debug:
-                        description: 'Set TLS debug verbosity level. It accept the
-                          following values: 0 (No debug), 1 (Error), 2 (State change),
-                          3 (Informational) and 4 Verbose'
+                        description: 'Set TLS debug verbosity level. It accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose'
                         enum:
                         - 0
                         - 1
@@ -4026,26 +2962,19 @@ spec:
                         description: Optional password for tls.key_file file
                         properties:
                           valueFrom:
-                            description: ValueSource represents a source for the value
-                              of a secret.
+                            description: ValueSource represents a source for the value of a secret.
                             properties:
                               secretKeyRef:
-                                description: Selects a key of a secret in the pod's
-                                  namespace
+                                description: Selects a key of a secret in the pod's namespace
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.  Must
-                                      be a valid secret key.
+                                    description: The key of the secret to select from.  Must be a valid secret key.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the Secret or its
-                                      key must be defined
+                                    description: Specify whether the Secret or its key must be defined
                                     type: boolean
                                 required:
                                 - key
@@ -4092,14 +3021,10 @@ spec:
         description: Parser is the Schema for the parsers API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -4107,21 +3032,14 @@ spec:
             description: ParserSpec defines the desired state of Parser
             properties:
               decoders:
-                description: 'Decoders are a built-in feature available through the
-                  Parsers file, each Parser definition can optionally set one or multiple
-                  decoders. There are two type of decoders type: Decode_Field and
-                  Decode_Field_As.'
+                description: 'Decoders are a built-in feature available through the Parsers file, each Parser definition can optionally set one or multiple decoders. There are two type of decoders type: Decode_Field and Decode_Field_As.'
                 items:
                   properties:
                     decodeField:
-                      description: If the content can be decoded in a structured message,
-                        append that structure message (keys and values) to the original
-                        log message.
+                      description: If the content can be decoded in a structured message, append that structure message (keys and values) to the original log message.
                       type: string
                     decodeFieldAs:
-                      description: Any content decoded (unstructured or structured)
-                        will be replaced in the same key/value, no extra keys are
-                        added.
+                      description: Any content decoded (unstructured or structured) will be replaced in the same key/value, no extra keys are added.
                       type: string
                   type: object
                 type: array

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -24,14 +24,10 @@ spec:
         description: Filter defines a Filter configuration.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -46,42 +42,33 @@ spec:
                       description: Grep defines Grep Filter configuration.
                       properties:
                         exclude:
-                          description: 'Exclude records which field matches the regular
-                            expression. Value Format: FIELD REGEX'
+                          description: 'Exclude records which field matches the regular expression. Value Format: FIELD REGEX'
                           type: string
                         regex:
-                          description: 'Keep records which field matches the regular
-                            expression. Value Format: FIELD REGEX'
+                          description: 'Keep records which field matches the regular expression. Value Format: FIELD REGEX'
                           type: string
                       type: object
                     kubernetes:
                       description: Kubernetes defines Kubernetes Filter configuration.
                       properties:
                         annotations:
-                          description: Include Kubernetes resource annotations in
-                            the extra metadata.
+                          description: Include Kubernetes resource annotations in the extra metadata.
                           type: boolean
                         bufferSize:
-                          description: Set the buffer size for HTTP client when reading
-                            responses from Kubernetes API server.
+                          description: Set the buffer size for HTTP client when reading responses from Kubernetes API server.
                           pattern: ^\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$
                           type: string
                         dummyMeta:
                           description: If set, use dummy-meta data (for test/dev purposes)
                           type: boolean
                         k8sLoggingExclude:
-                          description: Allow Kubernetes Pods to exclude their logs
-                            from the log processor (read more about it in Kubernetes
-                            Annotations section).
+                          description: Allow Kubernetes Pods to exclude their logs from the log processor (read more about it in Kubernetes Annotations section).
                           type: boolean
                         k8sLoggingParser:
-                          description: Allow Kubernetes Pods to suggest a pre-defined
-                            Parser (read more about it in Kubernetes Annotations section)
+                          description: Allow Kubernetes Pods to suggest a pre-defined Parser (read more about it in Kubernetes Annotations section)
                           type: boolean
                         keepLog:
-                          description: When Keep_Log is disabled, the log field is
-                            removed from the incoming message once it has been successfully
-                            merged (Merge_Log must be enabled as well).
+                          description: When Keep_Log is disabled, the log field is removed from the incoming message once it has been successfully merged (Merge_Log must be enabled as well).
                           type: boolean
                         kubeCAFile:
                           description: CA certificate file
@@ -90,14 +77,10 @@ spec:
                           description: Absolute path to scan for certificate files
                           type: string
                         kubeMetaPreloadCacheDir:
-                          description: If set, Kubernetes meta-data can be cached/pre-loaded
-                            from files in JSON format in this directory, named as
-                            namespace-pod.meta
+                          description: If set, Kubernetes meta-data can be cached/pre-loaded from files in JSON format in this directory, named as namespace-pod.meta
                           type: string
                         kubeTagPrefix:
-                          description: When the source records comes from Tail input
-                            plugin, this option allows to specify what's the prefix
-                            used in Tail configuration.
+                          description: When the source records comes from Tail input plugin, this option allows to specify what's the prefix used in Tail configuration.
                           type: string
                         kubeTokenFile:
                           description: Token file
@@ -106,64 +89,42 @@ spec:
                           description: API Server end-point
                           type: string
                         labels:
-                          description: Include Kubernetes resource labels in the extra
-                            metadata.
+                          description: Include Kubernetes resource labels in the extra metadata.
                           type: boolean
                         mergeLog:
-                          description: When enabled, it checks if the log field content
-                            is a JSON string map, if so, it append the map fields
-                            as part of the log structure.
+                          description: When enabled, it checks if the log field content is a JSON string map, if so, it append the map fields as part of the log structure.
                           type: boolean
                         mergeLogKey:
-                          description: When Merge_Log is enabled, the filter tries
-                            to assume the log field from the incoming message is a
-                            JSON string message and make a structured representation
-                            of it at the same level of the log field in the map. Now
-                            if Merge_Log_Key is set (a string name), all the new structured
-                            fields taken from the original log content are inserted
-                            under the new key.
+                          description: When Merge_Log is enabled, the filter tries to assume the log field from the incoming message is a JSON string message and make a structured representation of it at the same level of the log field in the map. Now if Merge_Log_Key is set (a string name), all the new structured fields taken from the original log content are inserted under the new key.
                           type: string
                         mergeLogTrim:
-                          description: When Merge_Log is enabled, trim (remove possible
-                            \n or \r) field values.
+                          description: When Merge_Log is enabled, trim (remove possible \n or \r) field values.
                           type: boolean
                         mergeParser:
-                          description: Optional parser name to specify how to parse
-                            the data contained in the log key. Recommended use is
-                            for developers or testing only.
+                          description: Optional parser name to specify how to parse the data contained in the log key. Recommended use is for developers or testing only.
                           type: string
                         regexParser:
-                          description: Set an alternative Parser to process record
-                            Tag and extract pod_name, namespace_name, container_name
-                            and docker_id. The parser must be registered in a parsers
-                            file (refer to parser filter-kube-test as an example).
+                          description: Set an alternative Parser to process record Tag and extract pod_name, namespace_name, container_name and docker_id. The parser must be registered in a parsers file (refer to parser filter-kube-test as an example).
                           type: string
                         tlsDebug:
-                          description: Debug level between 0 (nothing) and 4 (every
-                            detail).
+                          description: Debug level between 0 (nothing) and 4 (every detail).
                           format: int32
                           type: integer
                         tlsVerify:
-                          description: When enabled, turns on certificate validation
-                            when connecting to the Kubernetes API server.
+                          description: When enabled, turns on certificate validation when connecting to the Kubernetes API server.
                           type: boolean
                         useJournal:
-                          description: When enabled, the filter reads logs coming
-                            in Journald format.
+                          description: When enabled, the filter reads logs coming in Journald format.
                           type: boolean
                       type: object
                     lua:
                       description: Lua defines Lua Filter configuration.
                       properties:
                         call:
-                          description: Lua function name that will be triggered to
-                            do filtering. It's assumed that the function is declared
-                            inside the Script defined above.
+                          description: Lua function name that will be triggered to do filtering. It's assumed that the function is declared inside the Script defined above.
                           type: string
                         protectedMode:
-                          description: If enabled, Lua script will be executed in
-                            protected mode. It prevents to crash when invalid Lua
-                            script is executed. Default is true.
+                          description: If enabled, Lua script will be executed in protected mode. It prevents to crash when invalid Lua script is executed. Default is true.
                           type: boolean
                         script:
                           description: Path to the Lua script that will be used.
@@ -172,30 +133,19 @@ spec:
                               description: The key to select.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
-                              description: Specify whether the ConfigMap or its key
-                                must be defined
+                              description: Specify whether the ConfigMap or its key must be defined
                               type: boolean
                           required:
                           - key
                           type: object
                         timeAsTable:
-                          description: By default when the Lua script is invoked,
-                            the record timestamp is passed as a Floating number which
-                            might lead to loss precision when the data is converted
-                            back. If you desire timestamp precision enabling this
-                            option will pass the timestamp as a Lua table with keys
-                            sec for seconds since epoch and nsec for nanoseconds.
+                          description: By default when the Lua script is invoked, the record timestamp is passed as a Floating number which might lead to loss precision when the data is converted back. If you desire timestamp precision enabling this option will pass the timestamp as a Lua table with keys sec for seconds since epoch and nsec for nanoseconds.
                           type: boolean
                         typeIntKey:
-                          description: If these keys are matched, the fields are converted
-                            to integer. If more than one key, delimit by space. Note
-                            that starting from Fluent Bit v1.6 integer data types
-                            are preserved and not converted to double as in previous
-                            versions.
+                          description: If these keys are matched, the fields are converted to integer. If more than one key, delimit by space. Note that starting from Fluent Bit v1.6 integer data types are preserved and not converted to double as in previous versions.
                           items:
                             type: string
                           type: array
@@ -207,8 +157,7 @@ spec:
                       description: Modify defines Modify Filter configuration.
                       properties:
                         conditions:
-                          description: All conditions have to be true for the rules
-                            to be applied.
+                          description: All conditions have to be true for the rules to be applied.
                           items:
                             description: The plugin supports the following conditions
                             properties:
@@ -226,38 +175,32 @@ spec:
                               keyValueDoesNotEqual:
                                 additionalProperties:
                                   type: string
-                                description: Is true if KEY exists and its value is
-                                  not VALUE
+                                description: Is true if KEY exists and its value is not VALUE
                                 type: object
                               keyValueDoesNotMatch:
                                 additionalProperties:
                                   type: string
-                                description: Is true if key KEY exists and its value
-                                  does not match VALUE
+                                description: Is true if key KEY exists and its value does not match VALUE
                                 type: object
                               keyValueEquals:
                                 additionalProperties:
                                   type: string
-                                description: Is true if KEY exists and its value is
-                                  VALUE
+                                description: Is true if KEY exists and its value is VALUE
                                 type: object
                               keyValueMatches:
                                 additionalProperties:
                                   type: string
-                                description: Is true if key KEY exists and its value
-                                  matches VALUE
+                                description: Is true if key KEY exists and its value matches VALUE
                                 type: object
                               matchingKeysDoNotHaveMatchingValues:
                                 additionalProperties:
                                   type: string
-                                description: Is true if all keys matching KEY have
-                                  values that do not match VALUE
+                                description: Is true if all keys matching KEY have values that do not match VALUE
                                 type: object
                               matchingKeysHaveMatchingValues:
                                 additionalProperties:
                                   type: string
-                                description: Is true if all keys matching KEY have
-                                  values that match VALUE
+                                description: Is true if all keys matching KEY have values that match VALUE
                                 type: object
                               noKeyMatches:
                                 description: Is true if no key matches regex KEY
@@ -265,64 +208,48 @@ spec:
                             type: object
                           type: array
                         rules:
-                          description: Rules are applied in the order they appear,
-                            with each rule operating on the result of the previous
-                            rule.
+                          description: Rules are applied in the order they appear, with each rule operating on the result of the previous rule.
                           items:
                             description: The plugin supports the following rules
                             properties:
                               add:
                                 additionalProperties:
                                   type: string
-                                description: Add a key/value pair with key KEY and
-                                  value VALUE if KEY does not exist
+                                description: Add a key/value pair with key KEY and value VALUE if KEY does not exist
                                 type: object
                               copy:
                                 additionalProperties:
                                   type: string
-                                description: Copy a key/value pair with key KEY to
-                                  COPIED_KEY if KEY exists AND COPIED_KEY does not
-                                  exist
+                                description: Copy a key/value pair with key KEY to COPIED_KEY if KEY exists AND COPIED_KEY does not exist
                                 type: object
                               hardCopy:
                                 additionalProperties:
                                   type: string
-                                description: Copy a key/value pair with key KEY to
-                                  COPIED_KEY if KEY exists. If COPIED_KEY already
-                                  exists, this field is overwritten
+                                description: Copy a key/value pair with key KEY to COPIED_KEY if KEY exists. If COPIED_KEY already exists, this field is overwritten
                                 type: object
                               hardRename:
                                 additionalProperties:
                                   type: string
-                                description: Rename a key/value pair with key KEY
-                                  to RENAMED_KEY if KEY exists. If RENAMED_KEY already
-                                  exists, this field is overwritten
+                                description: Rename a key/value pair with key KEY to RENAMED_KEY if KEY exists. If RENAMED_KEY already exists, this field is overwritten
                                 type: object
                               remove:
-                                description: Remove a key/value pair with key KEY
-                                  if it exists
+                                description: Remove a key/value pair with key KEY if it exists
                                 type: string
                               removeRegex:
-                                description: Remove all key/value pairs with key matching
-                                  regexp KEY
+                                description: Remove all key/value pairs with key matching regexp KEY
                                 type: string
                               removeWildcard:
-                                description: Remove all key/value pairs with key matching
-                                  wildcard KEY
+                                description: Remove all key/value pairs with key matching wildcard KEY
                                 type: string
                               rename:
                                 additionalProperties:
                                   type: string
-                                description: Rename a key/value pair with key KEY
-                                  to RENAMED_KEY if KEY exists AND RENAMED_KEY does
-                                  not exist
+                                description: Rename a key/value pair with key KEY to RENAMED_KEY if KEY exists AND RENAMED_KEY does not exist
                                 type: object
                               set:
                                 additionalProperties:
                                   type: string
-                                description: Add a key/value pair with key KEY and
-                                  value VALUE. If KEY already exists, this field is
-                                  overwritten
+                                description: Add a key/value pair with key KEY and value VALUE. If KEY already exists, this field is overwritten
                                 type: object
                             type: object
                           type: array
@@ -334,12 +261,10 @@ spec:
                           description: Prefix affected keys with this string
                           type: string
                         nestUnder:
-                          description: Nest records matching the Wildcard under this
-                            key
+                          description: Nest records matching the Wildcard under this key
                           type: string
                         nestedUnder:
-                          description: Lift records nested under the Nested_under
-                            key
+                          description: Lift records nested under the Nested_under key
                           type: string
                         operation:
                           description: Select the operation nest or lift
@@ -348,8 +273,7 @@ spec:
                           - lift
                           type: string
                         removePrefix:
-                          description: Remove prefix from affected keys if it matches
-                            this string
+                          description: Remove prefix from affected keys if it matches this string
                           type: string
                         wildcard:
                           description: Nest records which field matches the wildcard
@@ -364,28 +288,23 @@ spec:
                           description: Specify field name in record to parse.
                           type: string
                         parser:
-                          description: Specify the parser name to interpret the field.
-                            Multiple Parser entries are allowed (split by comma).
+                          description: Specify the parser name to interpret the field. Multiple Parser entries are allowed (split by comma).
                           type: string
                         preserveKey:
-                          description: Keep original Key_Name field in the parsed
-                            result. If false, the field will be removed.
+                          description: Keep original Key_Name field in the parsed result. If false, the field will be removed.
                           type: boolean
                         reserveData:
-                          description: Keep all other original fields in the parsed
-                            result. If false, all other original fields will be removed.
+                          description: Keep all other original fields in the parsed result. If false, all other original fields will be removed.
                           type: boolean
                         unescapeKey:
-                          description: 'If the key is a escaped string (e.g: stringify
-                            JSON), unescape the string before to apply the parser.'
+                          description: 'If the key is a escaped string (e.g: stringify JSON), unescape the string before to apply the parser.'
                           type: boolean
                       type: object
                     recordModifier:
                       description: RecordModifier defines Record Modifier Filter configuration.
                       properties:
                         records:
-                          description: Append fields. This parameter needs key and
-                            value pair.
+                          description: Append fields. This parameter needs key and value pair.
                           items:
                             type: string
                           type: array
@@ -404,34 +323,28 @@ spec:
                       description: Throttle defines a Throttle configuration.
                       properties:
                         interval:
-                          description: Interval is the time interval expressed in
-                            "sleep" format. e.g. 3s, 1.5m, 0.5h, etc.
+                          description: Interval is the time interval expressed in "sleep" format. e.g. 3s, 1.5m, 0.5h, etc.
                           pattern: ^\d+(\.[0-9]{0,2})?(s|m|h|d)?$
                           type: string
                         printStatus:
-                          description: PrintStatus represents whether to print status
-                            messages with current rate and the limits to information
-                            logs.
+                          description: PrintStatus represents whether to print status messages with current rate and the limits to information logs.
                           type: boolean
                         rate:
                           description: Rate is the amount of messages for the time.
                           format: int64
                           type: integer
                         window:
-                          description: Window is the amount of intervals to calculate
-                            average over.
+                          description: Window is the amount of intervals to calculate average over.
                           format: int64
                           type: integer
                       type: object
                   type: object
                 type: array
               match:
-                description: A pattern to match against the tags of incoming records.
-                  It's case sensitive and support the star (*) character as a wildcard.
+                description: A pattern to match against the tags of incoming records. It's case sensitive and support the star (*) character as a wildcard.
                 type: string
               matchRegex:
-                description: A regular expression to match against the tags of incoming
-                  records. Use this option if you want to use the full regex syntax.
+                description: A regular expression to match against the tags of incoming records. Use this option if you want to use the full regex syntax.
                 type: string
             type: object
         type: object
@@ -467,14 +380,10 @@ spec:
         description: FluentBitConfig is the Schema for the fluentbitconfigs API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -485,28 +394,18 @@ spec:
                 description: Select filter plugins
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements.
-                      The requirements are ANDed.
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies
-                            to.
+                          description: key is the label key that the selector applies to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
-                            merge patch.
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                           items:
                             type: string
                           type: array
@@ -518,39 +417,25 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
               inputSelector:
                 description: Select input plugins
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements.
-                      The requirements are ANDed.
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies
-                            to.
+                          description: key is the label key that the selector applies to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
-                            merge patch.
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                           items:
                             type: string
                           type: array
@@ -562,39 +447,25 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
               outputSelector:
                 description: Select output plugins
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements.
-                      The requirements are ANDed.
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies
-                            to.
+                          description: key is the label key that the selector applies to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
-                            merge patch.
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                           items:
                             type: string
                           type: array
@@ -606,39 +477,25 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
               parserSelector:
                 description: Select parser plugins
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements.
-                      The requirements are ANDed.
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies
-                            to.
+                          description: key is the label key that the selector applies to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
-                            merge patch.
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                           items:
                             type: string
                           type: array
@@ -650,16 +507,11 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
               service:
-                description: Service defines the global behaviour of the Fluent Bit
-                  engine.
+                description: Service defines the global behaviour of the Fluent Bit engine.
                 properties:
                   daemon:
                     description: If true go to background on start
@@ -735,14 +587,10 @@ spec:
         description: FluentBit is the Schema for the fluentbits API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -753,59 +601,29 @@ spec:
                 description: Pod's scheduling constraints.
                 properties:
                   nodeAffinity:
-                    description: Describes node affinity scheduling rules for the
-                      pod.
+                    description: Describes node affinity scheduling rules for the pod.
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to
-                          nodes that satisfy the affinity expressions specified by
-                          this field, but it may choose a node that violates one or
-                          more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node matches
-                          the corresponding matchExpressions; the node(s) with the
-                          highest sum are the most preferred.
+                        description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
                         items:
-                          description: An empty preferred scheduling term matches
-                            all objects with implicit weight 0 (i.e. it's a no-op).
-                            A null preferred scheduling term matches no objects (i.e.
-                            is also a no-op).
+                          description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                           properties:
                             preference:
-                              description: A node selector term, associated with the
-                                corresponding weight.
+                              description: A node selector term, associated with the corresponding weight.
                               properties:
                                 matchExpressions:
-                                  description: A list of node selector requirements
-                                    by node's labels.
+                                  description: A list of node selector requirements by node's labels.
                                   items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
+                                    description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector
-                                          applies to.
+                                        description: The label key that the selector applies to.
                                         type: string
                                       operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
+                                        description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
+                                        description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -815,33 +633,18 @@ spec:
                                     type: object
                                   type: array
                                 matchFields:
-                                  description: A list of node selector requirements
-                                    by node's fields.
+                                  description: A list of node selector requirements by node's fields.
                                   items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
+                                    description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector
-                                          applies to.
+                                        description: The label key that the selector applies to.
                                         type: string
                                       operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
+                                        description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
+                                        description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -852,8 +655,7 @@ spec:
                                   type: array
                               type: object
                             weight:
-                              description: Weight associated with matching the corresponding
-                                nodeSelectorTerm, in the range 1-100.
+                              description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -862,50 +664,26 @@ spec:
                           type: object
                         type: array
                       requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the affinity requirements specified by this
-                          field are not met at scheduling time, the pod will not be
-                          scheduled onto the node. If the affinity requirements specified
-                          by this field cease to be met at some point during pod execution
-                          (e.g. due to an update), the system may or may not try to
-                          eventually evict the pod from its node.
+                        description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
                         properties:
                           nodeSelectorTerms:
-                            description: Required. A list of node selector terms.
-                              The terms are ORed.
+                            description: Required. A list of node selector terms. The terms are ORed.
                             items:
-                              description: A null or empty node selector term matches
-                                no objects. The requirements of them are ANDed. The
-                                TopologySelectorTerm type implements a subset of the
-                                NodeSelectorTerm.
+                              description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                               properties:
                                 matchExpressions:
-                                  description: A list of node selector requirements
-                                    by node's labels.
+                                  description: A list of node selector requirements by node's labels.
                                   items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
+                                    description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector
-                                          applies to.
+                                        description: The label key that the selector applies to.
                                         type: string
                                       operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
+                                        description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
+                                        description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -915,33 +693,18 @@ spec:
                                     type: object
                                   type: array
                                 matchFields:
-                                  description: A list of node selector requirements
-                                    by node's fields.
+                                  description: A list of node selector requirements by node's fields.
                                   items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
+                                    description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector
-                                          applies to.
+                                        description: The label key that the selector applies to.
                                         type: string
                                       operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
+                                        description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
+                                        description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -957,61 +720,32 @@ spec:
                         type: object
                     type: object
                   podAffinity:
-                    description: Describes pod affinity scheduling rules (e.g. co-locate
-                      this pod in the same node, zone, etc. as some other pod(s)).
+                    description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to
-                          nodes that satisfy the affinity expressions specified by
-                          this field, but it may choose a node that violates one or
-                          more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node has
-                          pods which matches the corresponding podAffinityTerm; the
-                          node(s) with the highest sum are the most preferred.
+                        description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
                         items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm
-                            fields are added per-node to find the most preferred node(s)
+                          description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
                           properties:
                             podAffinityTerm:
-                              description: Required. A pod affinity term, associated
-                                with the corresponding weight.
+                              description: Required. A pod affinity term, associated with the corresponding weight.
                               properties:
                                 labelSelector:
-                                  description: A label query over a set of resources,
-                                    in this case pods.
+                                  description: A label query over a set of resources, in this case pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                       items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
+                                            description: key is the label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -1023,36 +757,22 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                 namespaces:
-                                  description: namespaces specifies which namespaces
-                                    the labelSelector applies to (matches against);
-                                    null or empty list means "this pod's namespace"
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                   items:
                                     type: string
                                   type: array
                                 topologyKey:
-                                  description: This pod should be co-located (affinity)
-                                    or not co-located (anti-affinity) with the pods
-                                    matching the labelSelector in the specified namespaces,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey
-                                    matches that of any node on which any of the selected
-                                    pods is running. Empty topologyKey is not allowed.
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                   type: string
                               required:
                               - topologyKey
                               type: object
                             weight:
-                              description: weight associated with matching the corresponding
-                                podAffinityTerm, in the range 1-100.
+                              description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -1061,52 +781,26 @@ spec:
                           type: object
                         type: array
                       requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the affinity requirements specified by this
-                          field are not met at scheduling time, the pod will not be
-                          scheduled onto the node. If the affinity requirements specified
-                          by this field cease to be met at some point during pod execution
-                          (e.g. due to a pod label update), the system may or may
-                          not try to eventually evict the pod from its node. When
-                          there are multiple elements, the lists of nodes corresponding
-                          to each podAffinityTerm are intersected, i.e. all terms
-                          must be satisfied.
+                        description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
                         items:
-                          description: Defines a set of pods (namely those matching
-                            the labelSelector relative to the given namespace(s))
-                            that this pod should be co-located (affinity) or not co-located
-                            (anti-affinity) with, where co-located is defined as running
-                            on a node whose value of the label with key <topologyKey>
-                            matches that of any node on which a pod of the set of
-                            pods is running
+                          description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
                           properties:
                             labelSelector:
-                              description: A label query over a set of resources,
-                                in this case pods.
+                              description: A label query over a set of resources, in this case pods.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
+                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
+                                        description: key is the label key that the selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
+                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -1118,29 +812,16 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
+                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                             namespaces:
-                              description: namespaces specifies which namespaces the
-                                labelSelector applies to (matches against); null or
-                                empty list means "this pod's namespace"
+                              description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                               items:
                                 type: string
                               type: array
                             topologyKey:
-                              description: This pod should be co-located (affinity)
-                                or not co-located (anti-affinity) with the pods matching
-                                the labelSelector in the specified namespaces, where
-                                co-located is defined as running on a node whose value
-                                of the label with key topologyKey matches that of
-                                any node on which any of the selected pods is running.
-                                Empty topologyKey is not allowed.
+                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                               type: string
                           required:
                           - topologyKey
@@ -1148,62 +829,32 @@ spec:
                         type: array
                     type: object
                   podAntiAffinity:
-                    description: Describes pod anti-affinity scheduling rules (e.g.
-                      avoid putting this pod in the same node, zone, etc. as some
-                      other pod(s)).
+                    description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to
-                          nodes that satisfy the anti-affinity expressions specified
-                          by this field, but it may choose a node that violates one
-                          or more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling anti-affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node has
-                          pods which matches the corresponding podAffinityTerm; the
-                          node(s) with the highest sum are the most preferred.
+                        description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
                         items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm
-                            fields are added per-node to find the most preferred node(s)
+                          description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
                           properties:
                             podAffinityTerm:
-                              description: Required. A pod affinity term, associated
-                                with the corresponding weight.
+                              description: Required. A pod affinity term, associated with the corresponding weight.
                               properties:
                                 labelSelector:
-                                  description: A label query over a set of resources,
-                                    in this case pods.
+                                  description: A label query over a set of resources, in this case pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                       items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
+                                            description: key is the label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -1215,36 +866,22 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                 namespaces:
-                                  description: namespaces specifies which namespaces
-                                    the labelSelector applies to (matches against);
-                                    null or empty list means "this pod's namespace"
+                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                   items:
                                     type: string
                                   type: array
                                 topologyKey:
-                                  description: This pod should be co-located (affinity)
-                                    or not co-located (anti-affinity) with the pods
-                                    matching the labelSelector in the specified namespaces,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey
-                                    matches that of any node on which any of the selected
-                                    pods is running. Empty topologyKey is not allowed.
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                   type: string
                               required:
                               - topologyKey
                               type: object
                             weight:
-                              description: weight associated with matching the corresponding
-                                podAffinityTerm, in the range 1-100.
+                              description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -1253,52 +890,26 @@ spec:
                           type: object
                         type: array
                       requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the anti-affinity requirements specified by
-                          this field are not met at scheduling time, the pod will
-                          not be scheduled onto the node. If the anti-affinity requirements
-                          specified by this field cease to be met at some point during
-                          pod execution (e.g. due to a pod label update), the system
-                          may or may not try to eventually evict the pod from its
-                          node. When there are multiple elements, the lists of nodes
-                          corresponding to each podAffinityTerm are intersected, i.e.
-                          all terms must be satisfied.
+                        description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
                         items:
-                          description: Defines a set of pods (namely those matching
-                            the labelSelector relative to the given namespace(s))
-                            that this pod should be co-located (affinity) or not co-located
-                            (anti-affinity) with, where co-located is defined as running
-                            on a node whose value of the label with key <topologyKey>
-                            matches that of any node on which a pod of the set of
-                            pods is running
+                          description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
                           properties:
                             labelSelector:
-                              description: A label query over a set of resources,
-                                in this case pods.
+                              description: A label query over a set of resources, in this case pods.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
+                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
+                                        description: key is the label key that the selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
+                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -1310,29 +921,16 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
+                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                             namespaces:
-                              description: namespaces specifies which namespaces the
-                                labelSelector applies to (matches against); null or
-                                empty list means "this pod's namespace"
+                              description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                               items:
                                 type: string
                               type: array
                             topologyKey:
-                              description: This pod should be co-located (affinity)
-                                or not co-located (anti-affinity) with the pods matching
-                                the labelSelector in the specified namespaces, where
-                                co-located is defined as running on a node whose value
-                                of the label with key topologyKey matches that of
-                                any node on which any of the selected pods is running.
-                                Empty topologyKey is not allowed.
+                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                               type: string
                           required:
                           - topologyKey
@@ -1355,12 +953,10 @@ spec:
               imagePullSecrets:
                 description: Fluent Bit image pull secret
                 items:
-                  description: LocalObjectReference contains enough information to
-                    let you locate the referenced object inside the same namespace.
+                  description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
                   properties:
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                       type: string
                   type: object
                 type: array
@@ -1370,46 +966,29 @@ spec:
                 description: NodeSelector
                 type: object
               positionDB:
-                description: Storage for position db. You will use it if tail input
-                  is enabled.
+                description: Storage for position db. You will use it if tail input is enabled.
                 properties:
                   awsElasticBlockStore:
-                    description: 'AWSElasticBlockStore represents an AWS Disk resource
-                      that is attached to a kubelet''s host machine and then exposed
-                      to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                    description: 'AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                     properties:
                       fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                          TODO: how do we prevent errors in the filesystem from compromising
-                          the machine'
+                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine'
                         type: string
                       partition:
-                        description: 'The partition in the volume that you want to
-                          mount. If omitted, the default is to mount by volume name.
-                          Examples: For volume /dev/sda1, you specify the partition
-                          as "1". Similarly, the volume partition for /dev/sda is
-                          "0" (or you can leave the property empty).'
+                        description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
                         format: int32
                         type: integer
                       readOnly:
-                        description: 'Specify "true" to force and set the ReadOnly
-                          property in VolumeMounts to "true". If omitted, the default
-                          is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                        description: 'Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                         type: boolean
                       volumeID:
-                        description: 'Unique ID of the persistent disk resource in
-                          AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                        description: 'Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                         type: string
                     required:
                     - volumeID
                     type: object
                   azureDisk:
-                    description: AzureDisk represents an Azure Data Disk mount on
-                      the host and bind mount to the pod.
+                    description: AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
                     properties:
                       cachingMode:
                         description: 'Host Caching mode: None, Read Only, Read Write.'
@@ -1421,35 +1000,26 @@ spec:
                         description: The URI the data disk in the blob storage
                         type: string
                       fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                         type: string
                       kind:
-                        description: 'Expected values Shared: multiple blob disks
-                          per storage account  Dedicated: single blob disk per storage
-                          account  Managed: azure managed data disk (only in managed
-                          availability set). defaults to shared'
+                        description: 'Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
                         type: string
                       readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
+                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                         type: boolean
                     required:
                     - diskName
                     - diskURI
                     type: object
                   azureFile:
-                    description: AzureFile represents an Azure File Service mount
-                      on the host and bind mount to the pod.
+                    description: AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
                     properties:
                       readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
+                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                         type: boolean
                       secretName:
-                        description: the name of secret that contains Azure Storage
-                          Account Name and Key
+                        description: the name of secret that contains Azure Storage Account Name and Key
                         type: string
                       shareName:
                         description: Share Name
@@ -1459,98 +1029,66 @@ spec:
                     - shareName
                     type: object
                   cephfs:
-                    description: CephFS represents a Ceph FS mount on the host that
-                      shares a pod's lifetime
+                    description: CephFS represents a Ceph FS mount on the host that shares a pod's lifetime
                     properties:
                       monitors:
-                        description: 'Required: Monitors is a collection of Ceph monitors
-                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        description: 'Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                         items:
                           type: string
                         type: array
                       path:
-                        description: 'Optional: Used as the mounted root, rather than
-                          the full Ceph tree, default is /'
+                        description: 'Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
                         type: string
                       readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts. More
-                          info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                         type: boolean
                       secretFile:
-                        description: 'Optional: SecretFile is the path to key ring
-                          for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        description: 'Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                         type: string
                       secretRef:
-                        description: 'Optional: SecretRef is reference to the authentication
-                          secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        description: 'Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                         properties:
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                       user:
-                        description: 'Optional: User is the rados user name, default
-                          is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        description: 'Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                         type: string
                     required:
                     - monitors
                     type: object
                   cinder:
-                    description: 'Cinder represents a cinder volume attached and mounted
-                      on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                    description: 'Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                     properties:
                       fsType:
-                        description: 'Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Examples: "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                        description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                         type: string
                       readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts. More
-                          info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                         type: boolean
                       secretRef:
-                        description: 'Optional: points to a secret object containing
-                          parameters used to connect to OpenStack.'
+                        description: 'Optional: points to a secret object containing parameters used to connect to OpenStack.'
                         properties:
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                       volumeID:
-                        description: 'volume id used to identify the volume in cinder.
-                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                        description: 'volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                         type: string
                     required:
                     - volumeID
                     type: object
                   configMap:
-                    description: ConfigMap represents a configMap that should populate
-                      this volume
+                    description: ConfigMap represents a configMap that should populate this volume
                     properties:
                       defaultMode:
-                        description: 'Optional: mode bits to use on created files
-                          by default. Must be a value between 0 and 0777. Defaults
-                          to 0644. Directories within the path are not affected by
-                          this setting. This might be in conflict with other options
-                          that affect the file mode, like fsGroup, and the result
-                          can be other mode bits set.'
+                        description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                         format: int32
                         type: integer
                       items:
-                        description: If unspecified, each key-value pair in the Data
-                          field of the referenced ConfigMap will be projected into
-                          the volume as a file whose name is the key and content is
-                          the value. If specified, the listed keys will be projected
-                          into the specified paths, and unlisted keys will not be
-                          present. If a key is specified which is not present in the
-                          ConfigMap, the volume setup will error unless it is marked
-                          optional. Paths must be relative and may not contain the
-                          '..' path or start with '..'.
+                        description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                         items:
                           description: Maps a string key to a path within a volume.
                           properties:
@@ -1558,19 +1096,11 @@ spec:
                               description: The key to project.
                               type: string
                             mode:
-                              description: 'Optional: mode bits to use on this file,
-                                must be a value between 0 and 0777. If not specified,
-                                the volume defaultMode will be used. This might be
-                                in conflict with other options that affect the file
-                                mode, like fsGroup, and the result can be other mode
-                                bits set.'
+                              description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                               format: int32
                               type: integer
                             path:
-                              description: The relative path of the file to map the
-                                key to. May not be an absolute path. May not contain
-                                the path element '..'. May not start with the string
-                                '..'.
+                              description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                               type: string
                           required:
                           - key
@@ -1578,121 +1108,81 @@ spec:
                           type: object
                         type: array
                       name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                       optional:
-                        description: Specify whether the ConfigMap or its keys must
-                          be defined
+                        description: Specify whether the ConfigMap or its keys must be defined
                         type: boolean
                     type: object
                   csi:
-                    description: CSI (Container Storage Interface) represents storage
-                      that is handled by an external CSI driver (Alpha feature).
+                    description: CSI (Container Storage Interface) represents storage that is handled by an external CSI driver (Alpha feature).
                     properties:
                       driver:
-                        description: Driver is the name of the CSI driver that handles
-                          this volume. Consult with your admin for the correct name
-                          as registered in the cluster.
+                        description: Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
                         type: string
                       fsType:
-                        description: Filesystem type to mount. Ex. "ext4", "xfs",
-                          "ntfs". If not provided, the empty value is passed to the
-                          associated CSI driver which will determine the default filesystem
-                          to apply.
+                        description: Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
                         type: string
                       nodePublishSecretRef:
-                        description: NodePublishSecretRef is a reference to the secret
-                          object containing sensitive information to pass to the CSI
-                          driver to complete the CSI NodePublishVolume and NodeUnpublishVolume
-                          calls. This field is optional, and  may be empty if no secret
-                          is required. If the secret object contains more than one
-                          secret, all secret references are passed.
+                        description: NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
                         properties:
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                       readOnly:
-                        description: Specifies a read-only configuration for the volume.
-                          Defaults to false (read/write).
+                        description: Specifies a read-only configuration for the volume. Defaults to false (read/write).
                         type: boolean
                       volumeAttributes:
                         additionalProperties:
                           type: string
-                        description: VolumeAttributes stores driver-specific properties
-                          that are passed to the CSI driver. Consult your driver's
-                          documentation for supported values.
+                        description: VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
                         type: object
                     required:
                     - driver
                     type: object
                   downwardAPI:
-                    description: DownwardAPI represents downward API about the pod
-                      that should populate this volume
+                    description: DownwardAPI represents downward API about the pod that should populate this volume
                     properties:
                       defaultMode:
-                        description: 'Optional: mode bits to use on created files
-                          by default. Must be a value between 0 and 0777. Defaults
-                          to 0644. Directories within the path are not affected by
-                          this setting. This might be in conflict with other options
-                          that affect the file mode, like fsGroup, and the result
-                          can be other mode bits set.'
+                        description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                         format: int32
                         type: integer
                       items:
                         description: Items is a list of downward API volume file
                         items:
-                          description: DownwardAPIVolumeFile represents information
-                            to create the file containing the pod field
+                          description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                           properties:
                             fieldRef:
-                              description: 'Required: Selects a field of the pod:
-                                only annotations, labels, name and namespace are supported.'
+                              description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
                               properties:
                                 apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
+                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
+                                  description: Path of the field to select in the specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                             mode:
-                              description: 'Optional: mode bits to use on this file,
-                                must be a value between 0 and 0777. If not specified,
-                                the volume defaultMode will be used. This might be
-                                in conflict with other options that affect the file
-                                mode, like fsGroup, and the result can be other mode
-                                bits set.'
+                              description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                               format: int32
                               type: integer
                             path:
-                              description: 'Required: Path is  the relative path name
-                                of the file to be created. Must not be absolute or
-                                contain the ''..'' path. Must be utf-8 encoded. The
-                                first item of the relative path must not start with
-                                ''..'''
+                              description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
                               type: string
                             resourceFieldRef:
-                              description: 'Selects a resource of the container: only
-                                resources limits and requests (limits.cpu, limits.memory,
-                                requests.cpu and requests.memory) are currently supported.'
+                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
                               properties:
                                 containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
+                                  description: 'Container name: required for volumes, optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
+                                  description: Specifies the output format of the exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
@@ -1707,47 +1197,31 @@ spec:
                         type: array
                     type: object
                   emptyDir:
-                    description: 'EmptyDir represents a temporary directory that shares
-                      a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                    description: 'EmptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                     properties:
                       medium:
-                        description: 'What type of storage medium should back this
-                          directory. The default is "" which means to use the node''s
-                          default medium. Must be an empty string (default) or Memory.
-                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                        description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                         type: string
                       sizeLimit:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'Total amount of local storage required for this
-                          EmptyDir volume. The size limit is also applicable for memory
-                          medium. The maximum usage on memory medium EmptyDir would
-                          be the minimum value between the SizeLimit specified here
-                          and the sum of memory limits of all containers in a pod.
-                          The default is nil which means that the limit is undefined.
-                          More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                        description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                     type: object
                   fc:
-                    description: FC represents a Fibre Channel resource that is attached
-                      to a kubelet's host machine and then exposed to the pod.
+                    description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
                     properties:
                       fsType:
-                        description: 'Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          TODO: how do we prevent errors in the filesystem from compromising
-                          the machine'
+                        description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine'
                         type: string
                       lun:
                         description: 'Optional: FC target lun number'
                         format: int32
                         type: integer
                       readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts.'
+                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                         type: boolean
                       targetWWNs:
                         description: 'Optional: FC target worldwide names (WWNs)'
@@ -1755,26 +1229,19 @@ spec:
                           type: string
                         type: array
                       wwids:
-                        description: 'Optional: FC volume world wide identifiers (wwids)
-                          Either wwids or combination of targetWWNs and lun must be
-                          set, but not both simultaneously.'
+                        description: 'Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
                         items:
                           type: string
                         type: array
                     type: object
                   flexVolume:
-                    description: FlexVolume represents a generic volume resource that
-                      is provisioned/attached using an exec based plugin.
+                    description: FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
                     properties:
                       driver:
-                        description: Driver is the name of the driver to use for this
-                          volume.
+                        description: Driver is the name of the driver to use for this volume.
                         type: string
                       fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". The default filesystem depends on FlexVolume
-                          script.
+                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                         type: string
                       options:
                         additionalProperties:
@@ -1782,84 +1249,52 @@ spec:
                         description: 'Optional: Extra command options if any.'
                         type: object
                       readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts.'
+                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                         type: boolean
                       secretRef:
-                        description: 'Optional: SecretRef is reference to the secret
-                          object containing sensitive information to pass to the plugin
-                          scripts. This may be empty if no secret object is specified.
-                          If the secret object contains more than one secret, all
-                          secrets are passed to the plugin scripts.'
+                        description: 'Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
                         properties:
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                     required:
                     - driver
                     type: object
                   flocker:
-                    description: Flocker represents a Flocker volume attached to a
-                      kubelet's host machine. This depends on the Flocker control
-                      service being running
+                    description: Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
                     properties:
                       datasetName:
-                        description: Name of the dataset stored as metadata -> name
-                          on the dataset for Flocker should be considered as deprecated
+                        description: Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
                         type: string
                       datasetUUID:
-                        description: UUID of the dataset. This is unique identifier
-                          of a Flocker dataset
+                        description: UUID of the dataset. This is unique identifier of a Flocker dataset
                         type: string
                     type: object
                   gcePersistentDisk:
-                    description: 'GCEPersistentDisk represents a GCE Disk resource
-                      that is attached to a kubelet''s host machine and then exposed
-                      to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                    description: 'GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                     properties:
                       fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                          TODO: how do we prevent errors in the filesystem from compromising
-                          the machine'
+                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine'
                         type: string
                       partition:
-                        description: 'The partition in the volume that you want to
-                          mount. If omitted, the default is to mount by volume name.
-                          Examples: For volume /dev/sda1, you specify the partition
-                          as "1". Similarly, the volume partition for /dev/sda is
-                          "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                         format: int32
                         type: integer
                       pdName:
-                        description: 'Unique name of the PD resource in GCE. Used
-                          to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        description: 'Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                         type: string
                       readOnly:
-                        description: 'ReadOnly here will force the ReadOnly setting
-                          in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                         type: boolean
                     required:
                     - pdName
                     type: object
                   gitRepo:
-                    description: 'GitRepo represents a git repository at a particular
-                      revision. DEPRECATED: GitRepo is deprecated. To provision a
-                      container with a git repo, mount an EmptyDir into an InitContainer
-                      that clones the repo using git, then mount the EmptyDir into
-                      the Pod''s container.'
+                    description: 'GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
                     properties:
                       directory:
-                        description: Target directory name. Must not contain or start
-                          with '..'.  If '.' is supplied, the volume directory will
-                          be the git repository.  Otherwise, if specified, the volume
-                          will contain the git repository in the subdirectory with
-                          the given name.
+                        description: Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
                         type: string
                       repository:
                         description: Repository URL
@@ -1871,51 +1306,35 @@ spec:
                     - repository
                     type: object
                   glusterfs:
-                    description: 'Glusterfs represents a Glusterfs mount on the host
-                      that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                    description: 'Glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                     properties:
                       endpoints:
-                        description: 'EndpointsName is the endpoint name that details
-                          Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                        description: 'EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                         type: string
                       path:
-                        description: 'Path is the Glusterfs volume path. More info:
-                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                        description: 'Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                         type: string
                       readOnly:
-                        description: 'ReadOnly here will force the Glusterfs volume
-                          to be mounted with read-only permissions. Defaults to false.
-                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                        description: 'ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                         type: boolean
                     required:
                     - endpoints
                     - path
                     type: object
                   hostPath:
-                    description: 'HostPath represents a pre-existing file or directory
-                      on the host machine that is directly exposed to the container.
-                      This is generally used for system agents or other privileged
-                      things that are allowed to see the host machine. Most containers
-                      will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                      --- TODO(jonesdl) We need to restrict who can use host directory
-                      mounts and who can/can not mount host directories as read/write.'
+                    description: 'HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.'
                     properties:
                       path:
-                        description: 'Path of the directory on the host. If the path
-                          is a symlink, it will follow the link to the real path.
-                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                        description: 'Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                         type: string
                       type:
-                        description: 'Type for HostPath Volume Defaults to "" More
-                          info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                        description: 'Type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                         type: string
                     required:
                     - path
                     type: object
                   iscsi:
-                    description: 'ISCSI represents an ISCSI Disk resource that is
-                      attached to a kubelet''s host machine and then exposed to the
-                      pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                    description: 'ISCSI represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                     properties:
                       chapAuthDiscovery:
                         description: whether support iSCSI Discovery CHAP authentication
@@ -1924,54 +1343,38 @@ spec:
                         description: whether support iSCSI Session CHAP authentication
                         type: boolean
                       fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                          TODO: how do we prevent errors in the filesystem from compromising
-                          the machine'
+                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine'
                         type: string
                       initiatorName:
-                        description: Custom iSCSI Initiator Name. If initiatorName
-                          is specified with iscsiInterface simultaneously, new iSCSI
-                          interface <target portal>:<volume name> will be created
-                          for the connection.
+                        description: Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
                         type: string
                       iqn:
                         description: Target iSCSI Qualified Name.
                         type: string
                       iscsiInterface:
-                        description: iSCSI Interface Name that uses an iSCSI transport.
-                          Defaults to 'default' (tcp).
+                        description: iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
                         type: string
                       lun:
                         description: iSCSI Target Lun number.
                         format: int32
                         type: integer
                       portals:
-                        description: iSCSI Target Portal List. The portal is either
-                          an IP or ip_addr:port if the port is other than default
-                          (typically TCP ports 860 and 3260).
+                        description: iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                         items:
                           type: string
                         type: array
                       readOnly:
-                        description: ReadOnly here will force the ReadOnly setting
-                          in VolumeMounts. Defaults to false.
+                        description: ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
                         type: boolean
                       secretRef:
                         description: CHAP Secret for iSCSI target and initiator authentication
                         properties:
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                       targetPortal:
-                        description: iSCSI Target Portal. The Portal is either an
-                          IP or ip_addr:port if the port is other than default (typically
-                          TCP ports 860 and 3260).
+                        description: iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                         type: string
                     required:
                     - iqn
@@ -1979,72 +1382,53 @@ spec:
                     - targetPortal
                     type: object
                   nfs:
-                    description: 'NFS represents an NFS mount on the host that shares
-                      a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                    description: 'NFS represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                     properties:
                       path:
-                        description: 'Path that is exported by the NFS server. More
-                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        description: 'Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                         type: string
                       readOnly:
-                        description: 'ReadOnly here will force the NFS export to be
-                          mounted with read-only permissions. Defaults to false. More
-                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        description: 'ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                         type: boolean
                       server:
-                        description: 'Server is the hostname or IP address of the
-                          NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        description: 'Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                         type: string
                     required:
                     - path
                     - server
                     type: object
                   persistentVolumeClaim:
-                    description: 'PersistentVolumeClaimVolumeSource represents a reference
-                      to a PersistentVolumeClaim in the same namespace. More info:
-                      https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                    description: 'PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                     properties:
                       claimName:
-                        description: 'ClaimName is the name of a PersistentVolumeClaim
-                          in the same namespace as the pod using this volume. More
-                          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                        description: 'ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                         type: string
                       readOnly:
-                        description: Will force the ReadOnly setting in VolumeMounts.
-                          Default false.
+                        description: Will force the ReadOnly setting in VolumeMounts. Default false.
                         type: boolean
                     required:
                     - claimName
                     type: object
                   photonPersistentDisk:
-                    description: PhotonPersistentDisk represents a PhotonController
-                      persistent disk attached and mounted on kubelets host machine
+                    description: PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
                     properties:
                       fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                         type: string
                       pdID:
-                        description: ID that identifies Photon Controller persistent
-                          disk
+                        description: ID that identifies Photon Controller persistent disk
                         type: string
                     required:
                     - pdID
                     type: object
                   portworxVolume:
-                    description: PortworxVolume represents a portworx volume attached
-                      and mounted on kubelets host machine
+                    description: PortworxVolume represents a portworx volume attached and mounted on kubelets host machine
                     properties:
                       fsType:
-                        description: FSType represents the filesystem type to mount
-                          Must be a filesystem type supported by the host operating
-                          system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
-                          if unspecified.
+                        description: FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                         type: string
                       readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
+                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                         type: boolean
                       volumeID:
                         description: VolumeID uniquely identifies a Portworx volume
@@ -2053,61 +1437,34 @@ spec:
                     - volumeID
                     type: object
                   projected:
-                    description: Items for all in one resources secrets, configmaps,
-                      and downward API
+                    description: Items for all in one resources secrets, configmaps, and downward API
                     properties:
                       defaultMode:
-                        description: Mode bits to use on created files by default.
-                          Must be a value between 0 and 0777. Directories within the
-                          path are not affected by this setting. This might be in
-                          conflict with other options that affect the file mode, like
-                          fsGroup, and the result can be other mode bits set.
+                        description: Mode bits to use on created files by default. Must be a value between 0 and 0777. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
                         format: int32
                         type: integer
                       sources:
                         description: list of volume projections
                         items:
-                          description: Projection that may be projected along with
-                            other supported volume types
+                          description: Projection that may be projected along with other supported volume types
                           properties:
                             configMap:
-                              description: information about the configMap data to
-                                project
+                              description: information about the configMap data to project
                               properties:
                                 items:
-                                  description: If unspecified, each key-value pair
-                                    in the Data field of the referenced ConfigMap
-                                    will be projected into the volume as a file whose
-                                    name is the key and content is the value. If specified,
-                                    the listed keys will be projected into the specified
-                                    paths, and unlisted keys will not be present.
-                                    If a key is specified which is not present in
-                                    the ConfigMap, the volume setup will error unless
-                                    it is marked optional. Paths must be relative
-                                    and may not contain the '..' path or start with
-                                    '..'.
+                                  description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
+                                    description: Maps a string key to a path within a volume.
                                     properties:
                                       key:
                                         description: The key to project.
                                         type: string
                                       mode:
-                                        description: 'Optional: mode bits to use on
-                                          this file, must be a value between 0 and
-                                          0777. If not specified, the volume defaultMode
-                                          will be used. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
+                                        description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: The relative path of the file
-                                          to map the key to. May not be an absolute
-                                          path. May not contain the path element '..'.
-                                          May not start with the string '..'.
+                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -2115,78 +1472,50 @@ spec:
                                     type: object
                                   type: array
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    keys must be defined
+                                  description: Specify whether the ConfigMap or its keys must be defined
                                   type: boolean
                               type: object
                             downwardAPI:
-                              description: information about the downwardAPI data
-                                to project
+                              description: information about the downwardAPI data to project
                               properties:
                                 items:
-                                  description: Items is a list of DownwardAPIVolume
-                                    file
+                                  description: Items is a list of DownwardAPIVolume file
                                   items:
-                                    description: DownwardAPIVolumeFile represents
-                                      information to create the file containing the
-                                      pod field
+                                    description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                                     properties:
                                       fieldRef:
-                                        description: 'Required: Selects a field of
-                                          the pod: only annotations, labels, name
-                                          and namespace are supported.'
+                                        description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
                                         properties:
                                           apiVersion:
-                                            description: Version of the schema the
-                                              FieldPath is written in terms of, defaults
-                                              to "v1".
+                                            description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                             type: string
                                           fieldPath:
-                                            description: Path of the field to select
-                                              in the specified API version.
+                                            description: Path of the field to select in the specified API version.
                                             type: string
                                         required:
                                         - fieldPath
                                         type: object
                                       mode:
-                                        description: 'Optional: mode bits to use on
-                                          this file, must be a value between 0 and
-                                          0777. If not specified, the volume defaultMode
-                                          will be used. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
+                                        description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: 'Required: Path is  the relative
-                                          path name of the file to be created. Must
-                                          not be absolute or contain the ''..'' path.
-                                          Must be utf-8 encoded. The first item of
-                                          the relative path must not start with ''..'''
+                                        description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
                                         type: string
                                       resourceFieldRef:
-                                        description: 'Selects a resource of the container:
-                                          only resources limits and requests (limits.cpu,
-                                          limits.memory, requests.cpu and requests.memory)
-                                          are currently supported.'
+                                        description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
                                         properties:
                                           containerName:
-                                            description: 'Container name: required
-                                              for volumes, optional for env vars'
+                                            description: 'Container name: required for volumes, optional for env vars'
                                             type: string
                                           divisor:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Specifies the output format
-                                              of the exposed resources, defaults to
-                                              "1"
+                                            description: Specifies the output format of the exposed resources, defaults to "1"
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           resource:
@@ -2204,39 +1533,19 @@ spec:
                               description: information about the secret data to project
                               properties:
                                 items:
-                                  description: If unspecified, each key-value pair
-                                    in the Data field of the referenced Secret will
-                                    be projected into the volume as a file whose name
-                                    is the key and content is the value. If specified,
-                                    the listed keys will be projected into the specified
-                                    paths, and unlisted keys will not be present.
-                                    If a key is specified which is not present in
-                                    the Secret, the volume setup will error unless
-                                    it is marked optional. Paths must be relative
-                                    and may not contain the '..' path or start with
-                                    '..'.
+                                  description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
+                                    description: Maps a string key to a path within a volume.
                                     properties:
                                       key:
                                         description: The key to project.
                                         type: string
                                       mode:
-                                        description: 'Optional: mode bits to use on
-                                          this file, must be a value between 0 and
-                                          0777. If not specified, the volume defaultMode
-                                          will be used. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
+                                        description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: The relative path of the file
-                                          to map the key to. May not be an absolute
-                                          path. May not contain the path element '..'.
-                                          May not start with the string '..'.
+                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -2244,42 +1553,24 @@ spec:
                                     type: object
                                   type: array
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
+                                  description: Specify whether the Secret or its key must be defined
                                   type: boolean
                               type: object
                             serviceAccountToken:
-                              description: information about the serviceAccountToken
-                                data to project
+                              description: information about the serviceAccountToken data to project
                               properties:
                                 audience:
-                                  description: Audience is the intended audience of
-                                    the token. A recipient of a token must identify
-                                    itself with an identifier specified in the audience
-                                    of the token, and otherwise should reject the
-                                    token. The audience defaults to the identifier
-                                    of the apiserver.
+                                  description: Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
                                   type: string
                                 expirationSeconds:
-                                  description: ExpirationSeconds is the requested
-                                    duration of validity of the service account token.
-                                    As the token approaches expiration, the kubelet
-                                    volume plugin will proactively rotate the service
-                                    account token. The kubelet will start trying to
-                                    rotate the token if the token is older than 80
-                                    percent of its time to live or if the token is
-                                    older than 24 hours.Defaults to 1 hour and must
-                                    be at least 10 minutes.
+                                  description: ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
                                   format: int64
                                   type: integer
                                 path:
-                                  description: Path is the path relative to the mount
-                                    point of the file to project the token into.
+                                  description: Path is the path relative to the mount point of the file to project the token into.
                                   type: string
                               required:
                               - path
@@ -2290,58 +1581,41 @@ spec:
                     - sources
                     type: object
                   quobyte:
-                    description: Quobyte represents a Quobyte mount on the host that
-                      shares a pod's lifetime
+                    description: Quobyte represents a Quobyte mount on the host that shares a pod's lifetime
                     properties:
                       group:
                         description: Group to map volume access to Default is no group
                         type: string
                       readOnly:
-                        description: ReadOnly here will force the Quobyte volume to
-                          be mounted with read-only permissions. Defaults to false.
+                        description: ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
                         type: boolean
                       registry:
-                        description: Registry represents a single or multiple Quobyte
-                          Registry services specified as a string as host:port pair
-                          (multiple entries are separated with commas) which acts
-                          as the central registry for volumes
+                        description: Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
                         type: string
                       tenant:
-                        description: Tenant owning the given Quobyte volume in the
-                          Backend Used with dynamically provisioned Quobyte volumes,
-                          value is set by the plugin
+                        description: Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                         type: string
                       user:
-                        description: User to map volume access to Defaults to serivceaccount
-                          user
+                        description: User to map volume access to Defaults to serivceaccount user
                         type: string
                       volume:
-                        description: Volume is a string that references an already
-                          created Quobyte volume by name.
+                        description: Volume is a string that references an already created Quobyte volume by name.
                         type: string
                     required:
                     - registry
                     - volume
                     type: object
                   rbd:
-                    description: 'RBD represents a Rados Block Device mount on the
-                      host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                    description: 'RBD represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
                     properties:
                       fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                          TODO: how do we prevent errors in the filesystem from compromising
-                          the machine'
+                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine'
                         type: string
                       image:
                         description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                         type: string
                       keyring:
-                        description: 'Keyring is the path to key ring for RBDUser.
-                          Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        description: 'Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                         type: string
                       monitors:
                         description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
@@ -2349,80 +1623,61 @@ spec:
                           type: string
                         type: array
                       pool:
-                        description: 'The rados pool name. Default is rbd. More info:
-                          https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        description: 'The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                         type: string
                       readOnly:
-                        description: 'ReadOnly here will force the ReadOnly setting
-                          in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                         type: boolean
                       secretRef:
-                        description: 'SecretRef is name of the authentication secret
-                          for RBDUser. If provided overrides keyring. Default is nil.
-                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        description: 'SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                         properties:
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                       user:
-                        description: 'The rados user name. Default is admin. More
-                          info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        description: 'The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                         type: string
                     required:
                     - image
                     - monitors
                     type: object
                   scaleIO:
-                    description: ScaleIO represents a ScaleIO persistent volume attached
-                      and mounted on Kubernetes nodes.
+                    description: ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
                     properties:
                       fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Default is "xfs".
+                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
                         type: string
                       gateway:
                         description: The host address of the ScaleIO API Gateway.
                         type: string
                       protectionDomain:
-                        description: The name of the ScaleIO Protection Domain for
-                          the configured storage.
+                        description: The name of the ScaleIO Protection Domain for the configured storage.
                         type: string
                       readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
+                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                         type: boolean
                       secretRef:
-                        description: SecretRef references to the secret for ScaleIO
-                          user and other sensitive information. If this is not provided,
-                          Login operation will fail.
+                        description: SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
                         properties:
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                       sslEnabled:
-                        description: Flag to enable/disable SSL communication with
-                          Gateway, default false
+                        description: Flag to enable/disable SSL communication with Gateway, default false
                         type: boolean
                       storageMode:
-                        description: Indicates whether the storage for a volume should
-                          be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                        description: Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
                         type: string
                       storagePool:
-                        description: The ScaleIO Storage Pool associated with the
-                          protection domain.
+                        description: The ScaleIO Storage Pool associated with the protection domain.
                         type: string
                       system:
-                        description: The name of the storage system as configured
-                          in ScaleIO.
+                        description: The name of the storage system as configured in ScaleIO.
                         type: string
                       volumeName:
-                        description: The name of a volume already created in the ScaleIO
-                          system that is associated with this volume source.
+                        description: The name of a volume already created in the ScaleIO system that is associated with this volume source.
                         type: string
                     required:
                     - gateway
@@ -2430,28 +1685,14 @@ spec:
                     - system
                     type: object
                   secret:
-                    description: 'Secret represents a secret that should populate
-                      this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                    description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                     properties:
                       defaultMode:
-                        description: 'Optional: mode bits to use on created files
-                          by default. Must be a value between 0 and 0777. Defaults
-                          to 0644. Directories within the path are not affected by
-                          this setting. This might be in conflict with other options
-                          that affect the file mode, like fsGroup, and the result
-                          can be other mode bits set.'
+                        description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                         format: int32
                         type: integer
                       items:
-                        description: If unspecified, each key-value pair in the Data
-                          field of the referenced Secret will be projected into the
-                          volume as a file whose name is the key and content is the
-                          value. If specified, the listed keys will be projected into
-                          the specified paths, and unlisted keys will not be present.
-                          If a key is specified which is not present in the Secret,
-                          the volume setup will error unless it is marked optional.
-                          Paths must be relative and may not contain the '..' path
-                          or start with '..'.
+                        description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                         items:
                           description: Maps a string key to a path within a volume.
                           properties:
@@ -2459,19 +1700,11 @@ spec:
                               description: The key to project.
                               type: string
                             mode:
-                              description: 'Optional: mode bits to use on this file,
-                                must be a value between 0 and 0777. If not specified,
-                                the volume defaultMode will be used. This might be
-                                in conflict with other options that affect the file
-                                mode, like fsGroup, and the result can be other mode
-                                bits set.'
+                              description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                               format: int32
                               type: integer
                             path:
-                              description: The relative path of the file to map the
-                                key to. May not be an absolute path. May not contain
-                                the path element '..'. May not start with the string
-                                '..'.
+                              description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                               type: string
                           required:
                           - key
@@ -2479,69 +1712,46 @@ spec:
                           type: object
                         type: array
                       optional:
-                        description: Specify whether the Secret or its keys must be
-                          defined
+                        description: Specify whether the Secret or its keys must be defined
                         type: boolean
                       secretName:
-                        description: 'Name of the secret in the pod''s namespace to
-                          use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                        description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                         type: string
                     type: object
                   storageos:
-                    description: StorageOS represents a StorageOS volume attached
-                      and mounted on Kubernetes nodes.
+                    description: StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
                     properties:
                       fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                         type: string
                       readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
+                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                         type: boolean
                       secretRef:
-                        description: SecretRef specifies the secret to use for obtaining
-                          the StorageOS API credentials.  If not specified, default
-                          values will be attempted.
+                        description: SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
                         properties:
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                       volumeName:
-                        description: VolumeName is the human-readable name of the
-                          StorageOS volume.  Volume names are only unique within a
-                          namespace.
+                        description: VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
                         type: string
                       volumeNamespace:
-                        description: VolumeNamespace specifies the scope of the volume
-                          within StorageOS.  If no namespace is specified then the
-                          Pod's namespace will be used.  This allows the Kubernetes
-                          name scoping to be mirrored within StorageOS for tighter
-                          integration. Set VolumeName to any name to override the
-                          default behaviour. Set to "default" if you are not using
-                          namespaces within StorageOS. Namespaces that do not pre-exist
-                          within StorageOS will be created.
+                        description: VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
                         type: string
                     type: object
                   vsphereVolume:
-                    description: VsphereVolume represents a vSphere volume attached
-                      and mounted on kubelets host machine
+                    description: VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
                     properties:
                       fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                         type: string
                       storagePolicyID:
-                        description: Storage Policy Based Management (SPBM) profile
-                          ID associated with the StoragePolicyName.
+                        description: Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
                         type: string
                       storagePolicyName:
-                        description: Storage Policy Based Management (SPBM) profile
-                          name.
+                        description: Storage Policy Based Management (SPBM) profile name.
                         type: string
                       volumePath:
                         description: Path that identifies vSphere volume vmdk
@@ -2560,8 +1770,7 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: 'Limits describes the maximum amount of compute resources
-                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                     type: object
                   requests:
                     additionalProperties:
@@ -2570,10 +1779,7 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: 'Requests describes the minimum amount of compute
-                      resources required. If Requests is omitted for a container,
-                      it defaults to Limits if that is explicitly specified, otherwise
-                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                     type: object
                 type: object
               runtimeClassName:
@@ -2587,40 +1793,23 @@ spec:
               tolerations:
                 description: Tolerations
                 items:
-                  description: The pod this Toleration is attached to tolerates any
-                    taint that matches the triple <key,value,effect> using the matching
-                    operator <operator>.
+                  description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
                   properties:
                     effect:
-                      description: Effect indicates the taint effect to match. Empty
-                        means match all taint effects. When specified, allowed values
-                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                       type: string
                     key:
-                      description: Key is the taint key that the toleration applies
-                        to. Empty means match all taint keys. If the key is empty,
-                        operator must be Exists; this combination means to match all
-                        values and all keys.
+                      description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                       type: string
                     operator:
-                      description: Operator represents a key's relationship to the
-                        value. Valid operators are Exists and Equal. Defaults to Equal.
-                        Exists is equivalent to wildcard for value, so that a pod
-                        can tolerate all taints of a particular category.
+                      description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
                       type: string
                     tolerationSeconds:
-                      description: TolerationSeconds represents the period of time
-                        the toleration (which must be of effect NoExecute, otherwise
-                        this field is ignored) tolerates the taint. By default, it
-                        is not set, which means tolerate the taint forever (do not
-                        evict). Zero and negative values will be treated as 0 (evict
-                        immediately) by the system.
+                      description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
                       format: int64
                       type: integer
                     value:
-                      description: Value is the taint value the toleration matches
-                        to. If the operator is Exists, the value should be empty,
-                        otherwise just a regular string.
+                      description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                       type: string
                   type: object
                 type: array
@@ -2659,14 +1848,10 @@ spec:
         description: Input is the Schema for the inputs API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -2674,8 +1859,7 @@ spec:
             description: InputSpec defines the desired state of Input
             properties:
               alias:
-                description: A user friendly alias name for this input plugin. Used
-                  in metrics for distinction of each configured input.
+                description: A user friendly alias name for this input plugin. Used in metrics for distinction of each configured input.
                 type: string
               dummy:
                 description: Dummy defines Dummy Input configuration.
@@ -2692,23 +1876,17 @@ spec:
                     format: int32
                     type: integer
                   tag:
-                    description: Tag name associated to all records comming from this
-                      plugin.
+                    description: Tag name associated to all records comming from this plugin.
                     type: string
                 type: object
               systemd:
                 description: Systemd defines Systemd Input configuration.
                 properties:
                   db:
-                    description: Specify the database file to keep track of monitored
-                      files and offsets.
+                    description: Specify the database file to keep track of monitored files and offsets.
                     type: string
                   dbSync:
-                    description: 'Set a default synchronization (I/O) method. values:
-                      Extra, Full, Normal, Off. This flag affects how the internal
-                      SQLite engine do synchronization to disk, for more details about
-                      each option please refer to this section. note: this option
-                      was introduced on Fluent Bit v1.4.6.'
+                    description: 'Set a default synchronization (I/O) method. values: Extra, Full, Normal, Off. This flag affects how the internal SQLite engine do synchronization to disk, for more details about each option please refer to this section. note: this option was introduced on Fluent Bit v1.4.6.'
                     enum:
                     - Extra
                     - Full
@@ -2716,86 +1894,57 @@ spec:
                     - "Off"
                     type: string
                   maxEntries:
-                    description: When Fluent Bit starts, the Journal might have a
-                      high number of logs in the queue. In order to avoid delays and
-                      reduce memory usage, this option allows to specify the maximum
-                      number of log entries that can be processed per round. Once
-                      the limit is reached, Fluent Bit will continue processing the
-                      remaining log entries once Journald performs the notification.
+                    description: When Fluent Bit starts, the Journal might have a high number of logs in the queue. In order to avoid delays and reduce memory usage, this option allows to specify the maximum number of log entries that can be processed per round. Once the limit is reached, Fluent Bit will continue processing the remaining log entries once Journald performs the notification.
                     type: integer
                   maxFields:
-                    description: Set a maximum number of fields (keys) allowed per
-                      record.
+                    description: Set a maximum number of fields (keys) allowed per record.
                     type: integer
                   path:
-                    description: Optional path to the Systemd journal directory, if
-                      not set, the plugin will use default paths to read local-only
-                      logs.
+                    description: Optional path to the Systemd journal directory, if not set, the plugin will use default paths to read local-only logs.
                     type: string
                   readFromTail:
-                    description: Start reading new entries. Skip entries already stored
-                      in Journald.
+                    description: Start reading new entries. Skip entries already stored in Journald.
                     enum:
                     - "on"
                     - "off"
                     type: string
                   stripUnderscores:
-                    description: Remove the leading underscore of the Journald field
-                      (key). For example the Journald field _PID becomes the key PID.
+                    description: Remove the leading underscore of the Journald field (key). For example the Journald field _PID becomes the key PID.
                     enum:
                     - "on"
                     - "off"
                     type: string
                   systemdFilter:
-                    description: 'Allows to perform a query over logs that contains
-                      a specific Journald key/value pairs, e.g: _SYSTEMD_UNIT=UNIT.
-                      The Systemd_Filter option can be specified multiple times in
-                      the input section to apply multiple filters as required.'
+                    description: 'Allows to perform a query over logs that contains a specific Journald key/value pairs, e.g: _SYSTEMD_UNIT=UNIT. The Systemd_Filter option can be specified multiple times in the input section to apply multiple filters as required.'
                     items:
                       type: string
                     type: array
                   systemdFilterType:
-                    description: Define the filter type when Systemd_Filter is specified
-                      multiple times. Allowed values are And and Or. With And a record
-                      is matched only when all of the Systemd_Filter have a match.
-                      With Or a record is matched when any of the Systemd_Filter has
-                      a match.
+                    description: Define the filter type when Systemd_Filter is specified multiple times. Allowed values are And and Or. With And a record is matched only when all of the Systemd_Filter have a match. With Or a record is matched when any of the Systemd_Filter has a match.
                     enum:
                     - And
                     - Or
                     type: string
                   tag:
-                    description: 'The tag is used to route messages but on Systemd
-                      plugin there is an extra functionality: if the tag includes
-                      a star/wildcard, it will be expanded with the Systemd Unit file
-                      (e.g: host.* => host.UNIT_NAME).'
+                    description: 'The tag is used to route messages but on Systemd plugin there is an extra functionality: if the tag includes a star/wildcard, it will be expanded with the Systemd Unit file (e.g: host.* => host.UNIT_NAME).'
                     type: string
                 type: object
               tail:
                 description: Tail defines Tail Input configuration.
                 properties:
                   bufferChunkSize:
-                    description: Set the initial buffer size to read files data. This
-                      value is used too to increase buffer size. The value must be
-                      according to the Unit Size specification.
+                    description: Set the initial buffer size to read files data. This value is used too to increase buffer size. The value must be according to the Unit Size specification.
                     pattern: ^\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$
                     type: string
                   bufferMaxSize:
-                    description: 'Set the limit of the buffer size per monitored file.
-                      When a buffer needs to be increased (e.g: very long lines),
-                      this value is used to restrict how much the memory buffer can
-                      grow. If reading a file exceed this limit, the file is removed
-                      from the monitored file list The value must be according to
-                      the Unit Size specification.'
+                    description: 'Set the limit of the buffer size per monitored file. When a buffer needs to be increased (e.g: very long lines), this value is used to restrict how much the memory buffer can grow. If reading a file exceed this limit, the file is removed from the monitored file list The value must be according to the Unit Size specification.'
                     pattern: ^\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$
                     type: string
                   db:
-                    description: Specify the database file to keep track of monitored
-                      files and offsets.
+                    description: Specify the database file to keep track of monitored files and offsets.
                     type: string
                   dbSync:
-                    description: 'Set a default synchronization (I/O) method. Values:
-                      Extra, Full, Normal, Off.'
+                    description: 'Set a default synchronization (I/O) method. Values: Extra, Full, Normal, Off.'
                     enum:
                     - Extra
                     - Full
@@ -2803,97 +1952,65 @@ spec:
                     - "Off"
                     type: string
                   disableInotifyWatcher:
-                    description: DisableInotifyWatcher will disable inotify and use
-                      the file stat watcher instead.
+                    description: DisableInotifyWatcher will disable inotify and use the file stat watcher instead.
                     type: boolean
                   dockerMode:
-                    description: If enabled, the plugin will recombine split Docker
-                      log lines before passing them to any parser as configured above.
-                      This mode cannot be used at the same time as Multiline.
+                    description: If enabled, the plugin will recombine split Docker log lines before passing them to any parser as configured above. This mode cannot be used at the same time as Multiline.
                     type: boolean
                   dockerModeFlushSeconds:
-                    description: Wait period time in seconds to flush queued unfinished
-                      split lines.
+                    description: Wait period time in seconds to flush queued unfinished split lines.
                     format: int64
                     type: integer
                   excludePath:
-                    description: 'Set one or multiple shell patterns separated by
-                      commas to exclude files matching a certain criteria, e.g: exclude_path=*.gz,*.zip'
+                    description: 'Set one or multiple shell patterns separated by commas to exclude files matching a certain criteria, e.g: exclude_path=*.gz,*.zip'
                     type: string
                   ignoredOlder:
-                    description: Ignores records which are older than this time in
-                      seconds. Supports m,h,d (minutes, hours, days) syntax. Default
-                      behavior is to read all records from specified files. Only available
-                      when a Parser is specificied and it can parse the time of a
-                      record.
+                    description: Ignores records which are older than this time in seconds. Supports m,h,d (minutes, hours, days) syntax. Default behavior is to read all records from specified files. Only available when a Parser is specificied and it can parse the time of a record.
                     pattern: ^\d+(m|h|d)?$
                     type: string
                   key:
-                    description: When a message is unstructured (no parser applied),
-                      it's appended as a string under the key name log. This option
-                      allows to define an alternative name for that key.
+                    description: When a message is unstructured (no parser applied), it's appended as a string under the key name log. This option allows to define an alternative name for that key.
                     type: string
                   memBufLimit:
-                    description: Set a limit of memory that Tail plugin can use when
-                      appending data to the Engine. If the limit is reach, it will
-                      be paused; when the data is flushed it resumes.
+                    description: Set a limit of memory that Tail plugin can use when appending data to the Engine. If the limit is reach, it will be paused; when the data is flushed it resumes.
                     type: string
                   multiline:
-                    description: If enabled, the plugin will try to discover multiline
-                      messages and use the proper parsers to compose the outgoing
-                      messages. Note that when this option is enabled the Parser option
-                      is not used.
+                    description: If enabled, the plugin will try to discover multiline messages and use the proper parsers to compose the outgoing messages. Note that when this option is enabled the Parser option is not used.
                     type: boolean
                   multilineFlushSeconds:
-                    description: Wait period time in seconds to process queued multiline
-                      messages
+                    description: Wait period time in seconds to process queued multiline messages
                     format: int64
                     type: integer
                   parser:
-                    description: Specify the name of a parser to interpret the entry
-                      as a structured message.
+                    description: Specify the name of a parser to interpret the entry as a structured message.
                     type: string
                   parserFirstline:
-                    description: Name of the parser that matchs the beginning of a
-                      multiline message. Note that the regular expression defined
-                      in the parser must include a group name (named capture)
+                    description: Name of the parser that matchs the beginning of a multiline message. Note that the regular expression defined in the parser must include a group name (named capture)
                     type: string
                   parserN:
-                    description: Optional-extra parser to interpret and structure
-                      multiline entries. This option can be used to define multiple
-                      parsers.
+                    description: Optional-extra parser to interpret and structure multiline entries. This option can be used to define multiple parsers.
                     items:
                       type: string
                     type: array
                   path:
-                    description: Pattern specifying a specific log files or multiple
-                      ones through the use of common wildcards.
+                    description: Pattern specifying a specific log files or multiple ones through the use of common wildcards.
                     type: string
                   pathKey:
-                    description: If enabled, it appends the name of the monitored
-                      file as part of the record. The value assigned becomes the key
-                      in the map.
+                    description: If enabled, it appends the name of the monitored file as part of the record. The value assigned becomes the key in the map.
                     type: string
                   refreshIntervalSeconds:
-                    description: The interval of refreshing the list of watched files
-                      in seconds.
+                    description: The interval of refreshing the list of watched files in seconds.
                     format: int64
                     type: integer
                   rotateWaitSeconds:
-                    description: Specify the number of extra time in seconds to monitor
-                      a file once is rotated in case some pending data is flushed.
+                    description: Specify the number of extra time in seconds to monitor a file once is rotated in case some pending data is flushed.
                     format: int64
                     type: integer
                   skipLongLines:
-                    description: When a monitored file reach it buffer capacity due
-                      to a very long line (Buffer_Max_Size), the default behavior
-                      is to stop monitoring that file. Skip_Long_Lines alter that
-                      behavior and instruct Fluent Bit to skip long lines and continue
-                      processing other lines that fits into the buffer size.
+                    description: When a monitored file reach it buffer capacity due to a very long line (Buffer_Max_Size), the default behavior is to stop monitoring that file. Skip_Long_Lines alter that behavior and instruct Fluent Bit to skip long lines and continue processing other lines that fits into the buffer size.
                     type: boolean
                   tag:
-                    description: Set a tag (with regex-extract fields) that will be
-                      placed on lines read. E.g. kube.<namespace_name>.<pod_name>.<container_name>
+                    description: Set a tag (with regex-extract fields) that will be placed on lines read. E.g. kube.<namespace_name>.<pod_name>.<container_name>
                     type: string
                   tagRegex:
                     description: Set a regex to exctract fields from the file
@@ -2931,14 +2048,10 @@ spec:
         description: Output is the Schema for the outputs API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -2946,56 +2059,62 @@ spec:
             description: OutputSpec defines the desired state of Output
             properties:
               alias:
-                description: A user friendly alias name for this output plugin. Used
-                  in metrics for distinction of each configured output.
+                description: A user friendly alias name for this output plugin. Used in metrics for distinction of each configured output.
                 type: string
               es:
                 description: Elasticsearch defines Elasticsearch Output configuration.
                 properties:
+                  awsAuth:
+                    description: Enable AWS Sigv4 Authentication for Amazon ElasticSearch Service.
+                    type: string
+                  awsExternalID:
+                    description: External ID for the AWS IAM Role specified with aws_role_arn.
+                    type: string
+                  awsRegion:
+                    description: Specify the AWS region for Amazon ElasticSearch Service.
+                    type: string
+                  awsRoleARN:
+                    description: AWS IAM Role to assume to put records to your Amazon ES cluster.
+                    type: string
+                  awsSTSEndpoint:
+                    description: Specify the custom sts endpoint to be used with STS API for Amazon ElasticSearch Service.
+                    type: string
                   bufferSize:
-                    description: Specify the buffer size used to read the response
-                      from the Elasticsearch HTTP service. This option is useful for
-                      debugging purposes where is required to read full responses,
-                      note that response size grows depending of the number of records
-                      inserted. To set an unlimited amount of memory set this value
-                      to False, otherwise the value must be according to the Unit
-                      Size specification.
+                    description: Specify the buffer size used to read the response from the Elasticsearch HTTP service. This option is useful for debugging purposes where is required to read full responses, note that response size grows depending of the number of records inserted. To set an unlimited amount of memory set this value to False, otherwise the value must be according to the Unit Size specification.
                     pattern: ^\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$
                     type: string
+                  cloudAuth:
+                    description: Specify the credentials to use to connect to Elastic's Elasticsearch Service running on Elastic Cloud.
+                    type: string
+                  cloudID:
+                    description: If you are using Elastic's Elasticsearch Service you can specify the cloud_id of the cluster running.
+                    type: string
                   currentTimeIndex:
-                    description: Use current time for index generation instead of
-                      message record
+                    description: Use current time for index generation instead of message record
                     type: boolean
                   generateID:
-                    description: When enabled, generate _id for outgoing records.
-                      This prevents duplicate records when retrying ES.
+                    description: When enabled, generate _id for outgoing records. This prevents duplicate records when retrying ES.
                     type: boolean
                   host:
-                    description: IP address or hostname of the target Elasticsearch
-                      instance
+                    description: IP address or hostname of the target Elasticsearch instance
                     type: string
                   httpPassword:
                     description: Password for user defined in HTTP_User
                     properties:
                       valueFrom:
-                        description: ValueSource represents a source for the value
-                          of a secret.
+                        description: ValueSource represents a source for the value of a secret.
                         properties:
                           secretKeyRef:
                             description: Selects a key of a secret in the pod's namespace
                             properties:
                               key:
-                                description: The key of the secret to select from.  Must
-                                  be a valid secret key.
+                                description: The key of the secret to select from.  Must be a valid secret key.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
                               optional:
-                                description: Specify whether the Secret or its key
-                                  must be defined
+                                description: Specify whether the Secret or its key must be defined
                                 type: boolean
                             required:
                             - key
@@ -3006,30 +2125,28 @@ spec:
                     description: Optional username credential for Elastic X-Pack access
                     properties:
                       valueFrom:
-                        description: ValueSource represents a source for the value
-                          of a secret.
+                        description: ValueSource represents a source for the value of a secret.
                         properties:
                           secretKeyRef:
                             description: Selects a key of a secret in the pod's namespace
                             properties:
                               key:
-                                description: The key of the secret to select from.  Must
-                                  be a valid secret key.
+                                description: The key of the secret to select from.  Must be a valid secret key.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
                               optional:
-                                description: Specify whether the Secret or its key
-                                  must be defined
+                                description: Specify whether the Secret or its key must be defined
                                 type: boolean
                             required:
                             - key
                             type: object
                         type: object
                     type: object
+                  idKey:
+                    description: If set, _id will be the value of the key from incoming record and Generate_ID option is ignored.
+                    type: string
                   includeTagKey:
                     description: When enabled, it append the Tag name to the record.
                     type: boolean
@@ -3037,36 +2154,22 @@ spec:
                     description: Index name
                     type: string
                   logstashDateFormat:
-                    description: Time format (based on strftime) to generate the second
-                      part of the Index name.
+                    description: Time format (based on strftime) to generate the second part of the Index name.
                     type: string
                   logstashFormat:
-                    description: 'Enable Logstash format compatibility. This option
-                      takes a boolean value: True/False, On/Off'
+                    description: 'Enable Logstash format compatibility. This option takes a boolean value: True/False, On/Off'
                     type: boolean
                   logstashPrefix:
-                    description: 'When Logstash_Format is enabled, the Index name
-                      is composed using a prefix and the date, e.g: If Logstash_Prefix
-                      is equals to ''mydata'' your index will become ''mydata-YYYY.MM.DD''.
-                      The last string appended belongs to the date when the data is
-                      being generated.'
+                    description: 'When Logstash_Format is enabled, the Index name is composed using a prefix and the date, e.g: If Logstash_Prefix is equals to ''mydata'' your index will become ''mydata-YYYY.MM.DD''. The last string appended belongs to the date when the data is being generated.'
                     type: string
                   logstashPrefixKey:
                     description: Prefix keys with this string
                     type: string
                   path:
-                    description: Elasticsearch accepts new data on HTTP query path
-                      "/_bulk". But it is also possible to serve Elasticsearch behind
-                      a reverse proxy on a subpath. This option defines such path
-                      on the fluent-bit side. It simply adds a path prefix in the
-                      indexing HTTP POST URI.
+                    description: Elasticsearch accepts new data on HTTP query path "/_bulk". But it is also possible to serve Elasticsearch behind a reverse proxy on a subpath. This option defines such path on the fluent-bit side. It simply adds a path prefix in the indexing HTTP POST URI.
                     type: string
                   pipeline:
-                    description: Newer versions of Elasticsearch allows to setup filters
-                      called pipelines. This option allows to define which pipeline
-                      the database should use. For performance reasons is strongly
-                      suggested to do parsing and filtering on Fluent Bit side, avoid
-                      pipelines.
+                    description: Newer versions of Elasticsearch allows setting up filters called pipelines. This option allows defining which pipeline the database should use. For performance reasons is strongly suggested parsing and filtering on Fluent Bit side, avoid pipelines.
                     type: string
                   port:
                     description: TCP port of the target Elasticsearch instance
@@ -3075,26 +2178,22 @@ spec:
                     minimum: 1
                     type: integer
                   replaceDots:
-                    description: When enabled, replace field name dots with underscore,
-                      required by Elasticsearch 2.0-2.3.
+                    description: When enabled, replace field name dots with underscore, required by Elasticsearch 2.0-2.3.
                     type: boolean
+                  suppressTypeName:
+                    description: When enabled, mapping types is removed and Type option is ignored. Types are deprecated in APIs in v7.0. This options is for v7.0 or later.
+                    type: string
                   tagKey:
-                    description: When Include_Tag_Key is enabled, this property defines
-                      the key name for the tag.
+                    description: When Include_Tag_Key is enabled, this property defines the key name for the tag.
                     type: string
                   timeKey:
-                    description: When Logstash_Format is enabled, each record will
-                      get a new timestamp field. The Time_Key property defines the
-                      name of that field.
+                    description: When Logstash_Format is enabled, each record will get a new timestamp field. The Time_Key property defines the name of that field.
                     type: string
                   timeKeyFormat:
-                    description: When Logstash_Format is enabled, this property defines
-                      the format of the timestamp.
+                    description: When Logstash_Format is enabled, this property defines the format of the timestamp.
                     type: string
                   tls:
-                    description: Fluent Bit provides integrated support for Transport
-                      Layer Security (TLS) and it predecessor Secure Sockets Layer
-                      (SSL) respectively.
+                    description: Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.
                     properties:
                       caFile:
                         description: Absolute path to CA certificate file
@@ -3106,9 +2205,7 @@ spec:
                         description: Absolute path to Certificate file
                         type: string
                       debug:
-                        description: 'Set TLS debug verbosity level. It accept the
-                          following values: 0 (No debug), 1 (Error), 2 (State change),
-                          3 (Informational) and 4 Verbose'
+                        description: 'Set TLS debug verbosity level. It accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose'
                         enum:
                         - 0
                         - 1
@@ -3124,26 +2221,19 @@ spec:
                         description: Optional password for tls.key_file file
                         properties:
                           valueFrom:
-                            description: ValueSource represents a source for the value
-                              of a secret.
+                            description: ValueSource represents a source for the value of a secret.
                             properties:
                               secretKeyRef:
-                                description: Selects a key of a secret in the pod's
-                                  namespace
+                                description: Selects a key of a secret in the pod's namespace
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.  Must
-                                      be a valid secret key.
+                                    description: The key of the secret to select from.  Must be a valid secret key.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the Secret or its
-                                      key must be defined
+                                    description: Specify whether the Secret or its key must be defined
                                     type: boolean
                                 required:
                                 - key
@@ -3158,12 +2248,10 @@ spec:
                         type: string
                     type: object
                   traceError:
-                    description: When enabled print the elasticsearch API calls to
-                      stdout when elasticsearch returns an error
+                    description: When enabled print the elasticsearch API calls to stdout when elasticsearch returns an error
                     type: boolean
                   traceOutput:
-                    description: When enabled print the elasticsearch API calls to
-                      stdout (for diag only)
+                    description: When enabled print the elasticsearch API calls to stdout (for diag only)
                     type: boolean
                   type:
                     description: Type name
@@ -3173,16 +2261,13 @@ spec:
                 description: File defines File Output configuration.
                 properties:
                   delimiter:
-                    description: The character to separate each pair. Applicable only
-                      if format is csv or ltsv.
+                    description: The character to separate each pair. Applicable only if format is csv or ltsv.
                     type: string
                   file:
-                    description: Set file name to store the records. If not set, the
-                      file name will be the tag associated with the records.
+                    description: Set file name to store the records. If not set, the file name will be the tag associated with the records.
                     type: string
                   format:
-                    description: 'The format of the file content. See also Format
-                      section. Default: out_file.'
+                    description: 'The format of the file content. See also Format section. Default: out_file.'
                     enum:
                     - out_file
                     - plain
@@ -3191,12 +2276,10 @@ spec:
                     - template
                     type: string
                   labelDelimiter:
-                    description: The character to separate each pair. Applicable only
-                      if format is ltsv.
+                    description: The character to separate each pair. Applicable only if format is ltsv.
                     type: string
                   path:
-                    description: Absolute directory path to store files. If not set,
-                      Fluent Bit will write the files on it's own positioned directory.
+                    description: Absolute directory path to store files. If not set, Fluent Bit will write the files on it's own positioned directory.
                     type: string
                   template:
                     description: The format string. Applicable only if format is template.
@@ -3206,35 +2289,28 @@ spec:
                 description: Forward defines Forward Output configuration.
                 properties:
                   emptySharedKey:
-                    description: Use this option to connect to Fluentd with a zero-length
-                      secret.
+                    description: Use this option to connect to Fluentd with a zero-length secret.
                     type: boolean
                   host:
-                    description: Target host where Fluent-Bit or Fluentd are listening
-                      for Forward messages.
+                    description: Target host where Fluent-Bit or Fluentd are listening for Forward messages.
                     type: string
                   password:
                     description: Specify the password corresponding to the username.
                     properties:
                       valueFrom:
-                        description: ValueSource represents a source for the value
-                          of a secret.
+                        description: ValueSource represents a source for the value of a secret.
                         properties:
                           secretKeyRef:
                             description: Selects a key of a secret in the pod's namespace
                             properties:
                               key:
-                                description: The key of the secret to select from.  Must
-                                  be a valid secret key.
+                                description: The key of the secret to select from.  Must be a valid secret key.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
                               optional:
-                                description: Specify whether the Secret or its key
-                                  must be defined
+                                description: Specify whether the Secret or its key must be defined
                                 type: boolean
                             required:
                             - key
@@ -3248,29 +2324,22 @@ spec:
                     minimum: 1
                     type: integer
                   requireAckResponse:
-                    description: Send "chunk"-option and wait for "ack" response from
-                      server. Enables at-least-once and receiving server can control
-                      rate of traffic. (Requires Fluentd v0.14.0+ server)
+                    description: Send "chunk"-option and wait for "ack" response from server. Enables at-least-once and receiving server can control rate of traffic. (Requires Fluentd v0.14.0+ server)
                     type: boolean
                   selfHostname:
-                    description: Default value of the auto-generated certificate common
-                      name (CN).
+                    description: Default value of the auto-generated certificate common name (CN).
                     type: string
                   sendOptions:
                     description: Always send options (with "size"=count of messages)
                     type: boolean
                   sharedKey:
-                    description: A key string known by the remote Fluentd used for
-                      authorization.
+                    description: A key string known by the remote Fluentd used for authorization.
                     type: string
                   timeAsInteger:
-                    description: Set timestamps in integer format, it enable compatibility
-                      mode for Fluentd v0.12 series.
+                    description: Set timestamps in integer format, it enable compatibility mode for Fluentd v0.12 series.
                     type: boolean
                   tls:
-                    description: Fluent Bit provides integrated support for Transport
-                      Layer Security (TLS) and it predecessor Secure Sockets Layer
-                      (SSL) respectively.
+                    description: Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.
                     properties:
                       caFile:
                         description: Absolute path to CA certificate file
@@ -3282,9 +2351,7 @@ spec:
                         description: Absolute path to Certificate file
                         type: string
                       debug:
-                        description: 'Set TLS debug verbosity level. It accept the
-                          following values: 0 (No debug), 1 (Error), 2 (State change),
-                          3 (Informational) and 4 Verbose'
+                        description: 'Set TLS debug verbosity level. It accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose'
                         enum:
                         - 0
                         - 1
@@ -3300,26 +2367,19 @@ spec:
                         description: Optional password for tls.key_file file
                         properties:
                           valueFrom:
-                            description: ValueSource represents a source for the value
-                              of a secret.
+                            description: ValueSource represents a source for the value of a secret.
                             properties:
                               secretKeyRef:
-                                description: Selects a key of a secret in the pod's
-                                  namespace
+                                description: Selects a key of a secret in the pod's namespace
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.  Must
-                                      be a valid secret key.
+                                    description: The key of the secret to select from.  Must be a valid secret key.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the Secret or its
-                                      key must be defined
+                                    description: Specify whether the Secret or its key must be defined
                                     type: boolean
                                 required:
                                 - key
@@ -3334,28 +2394,22 @@ spec:
                         type: string
                     type: object
                   username:
-                    description: Specify the username to present to a Fluentd server
-                      that enables user_auth.
+                    description: Specify the username to present to a Fluentd server that enables user_auth.
                     properties:
                       valueFrom:
-                        description: ValueSource represents a source for the value
-                          of a secret.
+                        description: ValueSource represents a source for the value of a secret.
                         properties:
                           secretKeyRef:
                             description: Selects a key of a secret in the pod's namespace
                             properties:
                               key:
-                                description: The key of the secret to select from.  Must
-                                  be a valid secret key.
+                                description: The key of the secret to select from.  Must be a valid secret key.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
                               optional:
-                                description: Specify whether the Secret or its key
-                                  must be defined
+                                description: Specify whether the Secret or its key must be defined
                                 type: boolean
                             required:
                             - key
@@ -3367,17 +2421,13 @@ spec:
                 description: HTTP defines HTTP Output configuration.
                 properties:
                   allowDuplicatedHeaders:
-                    description: Specify if duplicated headers are allowed. If a duplicated
-                      header is found, the latest key/value set is preserved.
+                    description: Specify if duplicated headers are allowed. If a duplicated header is found, the latest key/value set is preserved.
                     type: boolean
                   compress:
-                    description: Set payload compression mechanism. Option available
-                      is 'gzip'
+                    description: Set payload compression mechanism. Option available is 'gzip'
                     type: string
                   format:
-                    description: Specify the data format to be used in the HTTP request
-                      body, by default it uses msgpack. Other supported formats are
-                      json, json_stream and json_lines and gelf.
+                    description: Specify the data format to be used in the HTTP request body, by default it uses msgpack. Other supported formats are json, json_stream and json_lines and gelf.
                     enum:
                     - msgpack
                     - json
@@ -3386,8 +2436,7 @@ spec:
                     - gelf
                     type: string
                   gelfFullMessageKey:
-                    description: Specify the key to use for the full message in gelf
-                      format
+                    description: Specify the key to use for the full message in gelf format
                     type: string
                   gelfHostKey:
                     description: Specify the key to use for the host in gelf format
@@ -3396,21 +2445,18 @@ spec:
                     description: Specify the key to use for the level in gelf format
                     type: string
                   gelfShortMessgeKey:
-                    description: Specify the key to use as the short message in gelf
-                      format
+                    description: Specify the key to use as the short message in gelf format
                     type: string
                   gelfTimestampKey:
                     description: Specify the key to use for timestamp in gelf format
                     type: string
                   headerTag:
-                    description: Specify an optional HTTP header field for the original
-                      message tag.
+                    description: Specify an optional HTTP header field for the original message tag.
                     type: string
                   headers:
                     additionalProperties:
                       type: string
-                    description: Add a HTTP header key/value pair. Multiple headers
-                      can be set.
+                    description: Add a HTTP header key/value pair. Multiple headers can be set.
                     type: object
                   host:
                     description: IP address or hostname of the target HTTP Server
@@ -3419,24 +2465,19 @@ spec:
                     description: Basic Auth Password. Requires HTTP_User to be set
                     properties:
                       valueFrom:
-                        description: ValueSource represents a source for the value
-                          of a secret.
+                        description: ValueSource represents a source for the value of a secret.
                         properties:
                           secretKeyRef:
                             description: Selects a key of a secret in the pod's namespace
                             properties:
                               key:
-                                description: The key of the secret to select from.  Must
-                                  be a valid secret key.
+                                description: The key of the secret to select from.  Must be a valid secret key.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
                               optional:
-                                description: Specify whether the Secret or its key
-                                  must be defined
+                                description: Specify whether the Secret or its key must be defined
                                 type: boolean
                             required:
                             - key
@@ -3447,24 +2488,19 @@ spec:
                     description: Basic Auth Username
                     properties:
                       valueFrom:
-                        description: ValueSource represents a source for the value
-                          of a secret.
+                        description: ValueSource represents a source for the value of a secret.
                         properties:
                           secretKeyRef:
                             description: Selects a key of a secret in the pod's namespace
                             properties:
                               key:
-                                description: The key of the secret to select from.  Must
-                                  be a valid secret key.
+                                description: The key of the secret to select from.  Must be a valid secret key.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
                               optional:
-                                description: Specify whether the Secret or its key
-                                  must be defined
+                                description: Specify whether the Secret or its key must be defined
                                 type: boolean
                             required:
                             - key
@@ -3472,12 +2508,10 @@ spec:
                         type: object
                     type: object
                   jsonDateFormat:
-                    description: 'Specify the format of the date. Supported formats
-                      are double, epoch and iso8601 (eg: 2018-05-30T09:39:52.000681Z)'
+                    description: 'Specify the format of the date. Supported formats are double, epoch and iso8601 (eg: 2018-05-30T09:39:52.000681Z)'
                     type: string
                   jsonDateKey:
-                    description: Specify the name of the time key in the output record.
-                      To disable the time key just set the value to false.
+                    description: Specify the name of the time key in the output record. To disable the time key just set the value to false.
                     type: string
                   port:
                     description: TCP port of the target HTTP Server
@@ -3486,14 +2520,10 @@ spec:
                     minimum: 1
                     type: integer
                   proxy:
-                    description: Specify an HTTP Proxy. The expected format of this
-                      value is http://host:port. Note that https is not supported
-                      yet.
+                    description: Specify an HTTP Proxy. The expected format of this value is http://host:port. Note that https is not supported yet.
                     type: string
                   tls:
-                    description: HTTP output plugin supports TTL/SSL, for more details
-                      about the properties available and general configuration, please
-                      refer to the TLS/SSL section.
+                    description: HTTP output plugin supports TTL/SSL, for more details about the properties available and general configuration, please refer to the TLS/SSL section.
                     properties:
                       caFile:
                         description: Absolute path to CA certificate file
@@ -3505,9 +2535,7 @@ spec:
                         description: Absolute path to Certificate file
                         type: string
                       debug:
-                        description: 'Set TLS debug verbosity level. It accept the
-                          following values: 0 (No debug), 1 (Error), 2 (State change),
-                          3 (Informational) and 4 Verbose'
+                        description: 'Set TLS debug verbosity level. It accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose'
                         enum:
                         - 0
                         - 1
@@ -3523,26 +2551,19 @@ spec:
                         description: Optional password for tls.key_file file
                         properties:
                           valueFrom:
-                            description: ValueSource represents a source for the value
-                              of a secret.
+                            description: ValueSource represents a source for the value of a secret.
                             properties:
                               secretKeyRef:
-                                description: Selects a key of a secret in the pod's
-                                  namespace
+                                description: Selects a key of a secret in the pod's namespace
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.  Must
-                                      be a valid secret key.
+                                    description: The key of the secret to select from.  Must be a valid secret key.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the Secret or its
-                                      key must be defined
+                                    description: Specify whether the Secret or its key must be defined
                                     type: boolean
                                 required:
                                 - key
@@ -3557,16 +2578,14 @@ spec:
                         type: string
                     type: object
                   uri:
-                    description: 'Specify an optional HTTP URI for the target web
-                      server, e.g: /something'
+                    description: 'Specify an optional HTTP URI for the target web server, e.g: /something'
                     type: string
                 type: object
               kafka:
                 description: Kafka defines Kafka Output configuration.
                 properties:
                   brokers:
-                    description: 'Single of multiple list of Kafka Brokers, e.g: 192.168.1.3:9092,
-                      192.168.1.4:9092.'
+                    description: 'Single of multiple list of Kafka Brokers, e.g: 192.168.1.3:9092, 192.168.1.4:9092.'
                     type: string
                   format:
                     description: 'Specify data format, options available: json, msgpack.'
@@ -3575,9 +2594,7 @@ spec:
                     description: Optional key to store the message
                     type: string
                   messageKeyField:
-                    description: If set, the value of Message_Key_Field in the record
-                      will indicate the message key. If not set nor found in the record,
-                      Message_Key will be used (if set).
+                    description: If set, the value of Message_Key_Field in the record will indicate the message key. If not set nor found in the record, Message_Key will be used (if set).
                     type: string
                   rdkafka:
                     additionalProperties:
@@ -3591,27 +2608,17 @@ spec:
                     description: Set the key to store the record timestamp
                     type: string
                   topicKey:
-                    description: 'If multiple Topics exists, the value of Topic_Key
-                      in the record will indicate the topic to use. E.g: if Topic_Key
-                      is router and the record is {"key1": 123, "router": "route_2"},
-                      Fluent Bit will use topic route_2. Note that if the value of
-                      Topic_Key is not present in Topics, then by default the first
-                      topic in the Topics list will indicate the topic to be used.'
+                    description: 'If multiple Topics exists, the value of Topic_Key in the record will indicate the topic to use. E.g: if Topic_Key is router and the record is {"key1": 123, "router": "route_2"}, Fluent Bit will use topic route_2. Note that if the value of Topic_Key is not present in Topics, then by default the first topic in the Topics list will indicate the topic to be used.'
                     type: string
                   topics:
-                    description: Single entry or list of topics separated by comma
-                      (,) that Fluent Bit will use to send messages to Kafka. If only
-                      one topic is set, that one will be used for all records. Instead
-                      if multiple topics exists, the one set in the record by Topic_Key
-                      will be used.
+                    description: Single entry or list of topics separated by comma (,) that Fluent Bit will use to send messages to Kafka. If only one topic is set, that one will be used for all records. Instead if multiple topics exists, the one set in the record by Topic_Key will be used.
                     type: string
                 type: object
               loki:
                 description: Loki defines Loki Output configuration.
                 properties:
                   autoKubernetesLabels:
-                    description: If set to true, it will add all Kubernetes labels
-                      to the Stream labels.
+                    description: If set to true, it will add all Kubernetes labels to the Stream labels.
                     enum:
                     - "on"
                     - "off"
@@ -3620,28 +2627,22 @@ spec:
                     description: Loki hostname or IP address.
                     type: string
                   httpPassword:
-                    description: Password for user defined in HTTP_User Set HTTP basic
-                      authentication password
+                    description: Password for user defined in HTTP_User Set HTTP basic authentication password
                     properties:
                       valueFrom:
-                        description: ValueSource represents a source for the value
-                          of a secret.
+                        description: ValueSource represents a source for the value of a secret.
                         properties:
                           secretKeyRef:
                             description: Selects a key of a secret in the pod's namespace
                             properties:
                               key:
-                                description: The key of the secret to select from.  Must
-                                  be a valid secret key.
+                                description: The key of the secret to select from.  Must be a valid secret key.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
                               optional:
-                                description: Specify whether the Secret or its key
-                                  must be defined
+                                description: Specify whether the Secret or its key must be defined
                                 type: boolean
                             required:
                             - key
@@ -3652,24 +2653,19 @@ spec:
                     description: Set HTTP basic authentication user name.
                     properties:
                       valueFrom:
-                        description: ValueSource represents a source for the value
-                          of a secret.
+                        description: ValueSource represents a source for the value of a secret.
                         properties:
                           secretKeyRef:
                             description: Selects a key of a secret in the pod's namespace
                             properties:
                               key:
-                                description: The key of the secret to select from.  Must
-                                  be a valid secret key.
+                                description: The key of the secret to select from.  Must be a valid secret key.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
                               optional:
-                                description: Specify whether the Secret or its key
-                                  must be defined
+                                description: Specify whether the Secret or its key must be defined
                                 type: boolean
                             required:
                             - key
@@ -3677,27 +2673,17 @@ spec:
                         type: object
                     type: object
                   labelKeys:
-                    description: Optional list of record keys that will be placed
-                      as stream labels. This configuration property is for records
-                      key only.
+                    description: Optional list of record keys that will be placed as stream labels. This configuration property is for records key only.
                     items:
                       type: string
                     type: array
                   labels:
-                    description: Stream labels for API request. It can be multiple
-                      comma separated of strings specifying  key=value pairs. In addition
-                      to fixed parameters, it also allows to add custom record keys
-                      (similar to label_keys property).
+                    description: Stream labels for API request. It can be multiple comma separated of strings specifying  key=value pairs. In addition to fixed parameters, it also allows to add custom record keys (similar to label_keys property).
                     items:
                       type: string
                     type: array
                   lineFormat:
-                    description: Format to use when flattening the record to a log
-                      line. Valid values are json or key_value. If set to json,  the
-                      log line sent to Loki will be the Fluent Bit record dumped as
-                      JSON. If set to key_value, the log line will be each item in
-                      the record concatenated together (separated by a single space)
-                      in the format.
+                    description: Format to use when flattening the record to a log line. Valid values are json or key_value. If set to json,  the log line sent to Loki will be the Fluent Bit record dumped as JSON. If set to key_value, the log line will be each item in the record concatenated together (separated by a single space) in the format.
                     enum:
                     - json
                     - key_value
@@ -3709,29 +2695,22 @@ spec:
                     minimum: 1
                     type: integer
                   tenantID:
-                    description: Tenant ID used by default to push logs to Loki. If
-                      omitted or empty it assumes Loki is running in single-tenant
-                      mode and no X-Scope-OrgID header is sent.
+                    description: Tenant ID used by default to push logs to Loki. If omitted or empty it assumes Loki is running in single-tenant mode and no X-Scope-OrgID header is sent.
                     properties:
                       valueFrom:
-                        description: ValueSource represents a source for the value
-                          of a secret.
+                        description: ValueSource represents a source for the value of a secret.
                         properties:
                           secretKeyRef:
                             description: Selects a key of a secret in the pod's namespace
                             properties:
                               key:
-                                description: The key of the secret to select from.  Must
-                                  be a valid secret key.
+                                description: The key of the secret to select from.  Must be a valid secret key.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
                               optional:
-                                description: Specify whether the Secret or its key
-                                  must be defined
+                                description: Specify whether the Secret or its key must be defined
                                 type: boolean
                             required:
                             - key
@@ -3739,9 +2718,7 @@ spec:
                         type: object
                     type: object
                   tls:
-                    description: Fluent Bit provides integrated support for Transport
-                      Layer Security (TLS) and it predecessor Secure Sockets Layer
-                      (SSL) respectively.
+                    description: Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.
                     properties:
                       caFile:
                         description: Absolute path to CA certificate file
@@ -3753,9 +2730,7 @@ spec:
                         description: Absolute path to Certificate file
                         type: string
                       debug:
-                        description: 'Set TLS debug verbosity level. It accept the
-                          following values: 0 (No debug), 1 (Error), 2 (State change),
-                          3 (Informational) and 4 Verbose'
+                        description: 'Set TLS debug verbosity level. It accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose'
                         enum:
                         - 0
                         - 1
@@ -3771,26 +2746,19 @@ spec:
                         description: Optional password for tls.key_file file
                         properties:
                           valueFrom:
-                            description: ValueSource represents a source for the value
-                              of a secret.
+                            description: ValueSource represents a source for the value of a secret.
                             properties:
                               secretKeyRef:
-                                description: Selects a key of a secret in the pod's
-                                  namespace
+                                description: Selects a key of a secret in the pod's namespace
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.  Must
-                                      be a valid secret key.
+                                    description: The key of the secret to select from.  Must be a valid secret key.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the Secret or its
-                                      key must be defined
+                                    description: Specify whether the Secret or its key must be defined
                                     type: boolean
                                 required:
                                 - key
@@ -3808,12 +2776,10 @@ spec:
                 - host
                 type: object
               match:
-                description: A pattern to match against the tags of incoming records.
-                  It's case sensitive and support the star (*) character as a wildcard.
+                description: A pattern to match against the tags of incoming records. It's case sensitive and support the star (*) character as a wildcard.
                 type: string
               matchRegex:
-                description: A regular expression to match against the tags of incoming
-                  records. Use this option if you want to use the full regex syntax.
+                description: A regular expression to match against the tags of incoming records. Use this option if you want to use the full regex syntax.
                 type: string
               "null":
                 description: Null defines Null Output configuration.
@@ -3822,8 +2788,7 @@ spec:
                 description: Stdout defines Stdout Output configuration.
                 properties:
                   format:
-                    description: Specify the data format to be printed. Supported
-                      formats are msgpack json, json_lines and json_stream.
+                    description: Specify the data format to be printed. Supported formats are msgpack json, json_lines and json_stream.
                     enum:
                     - msgpack
                     - json
@@ -3831,8 +2796,7 @@ spec:
                     - json_stream
                     type: string
                   jsonDateFormat:
-                    description: 'Specify the format of the date. Supported formats
-                      are double,  iso8601 (eg: 2018-05-30T09:39:52.000681Z) and epoch.'
+                    description: 'Specify the format of the date. Supported formats are double,  iso8601 (eg: 2018-05-30T09:39:52.000681Z) and epoch.'
                     enum:
                     - double
                     - iso8601
@@ -3849,8 +2813,7 @@ spec:
                     description: Host domain or IP address of the remote Syslog server.
                     type: string
                   mode:
-                    description: Mode of the desired transport type, the available
-                      options are tcp, tls and udp.
+                    description: Mode of the desired transport type, the available options are tcp, tls and udp.
                     type: string
                   port:
                     description: TCP or UDP port of the remote Syslog server.
@@ -3859,48 +2822,38 @@ spec:
                     minimum: 1
                     type: integer
                   syslogAppnameKey:
-                    description: Key name from the original record that contains the
-                      application name that generated the message.
+                    description: Key name from the original record that contains the application name that generated the message.
                     type: string
                   syslogFacilityKey:
-                    description: Key from the original record that contains the Syslog
-                      facility number.
+                    description: Key from the original record that contains the Syslog facility number.
                     type: string
                   syslogFormat:
-                    description: Syslog protocol format to use, the available options
-                      are rfc3164 and rfc5424.
+                    description: Syslog protocol format to use, the available options are rfc3164 and rfc5424.
                     type: string
                   syslogHostnameKey:
-                    description: Key name from the original record that contains the
-                      hostname that generated the message.
+                    description: Key name from the original record that contains the hostname that generated the message.
                     type: string
                   syslogMaxSize:
                     description: Maximum size allowed per message, in bytes.
                     format: int32
                     type: integer
                   syslogMessageIDKey:
-                    description: Key name from the original record that contains the
-                      Message ID associated to the message.
+                    description: Key name from the original record that contains the Message ID associated to the message.
                     type: string
                   syslogMessageKey:
                     description: Key key name that contains the message to deliver.
                     type: string
                   syslogProcessIDKey:
-                    description: Key name from the original record that contains the
-                      Process ID that generated the message.
+                    description: Key name from the original record that contains the Process ID that generated the message.
                     type: string
                   syslogSDKey:
-                    description: Key name from the original record that contains the
-                      Structured Data (SD) content.
+                    description: Key name from the original record that contains the Structured Data (SD) content.
                     type: string
                   syslogSeverityKey:
-                    description: Key from the original record that contains the Syslog
-                      severity number.
+                    description: Key from the original record that contains the Syslog severity number.
                     type: string
                   tls:
-                    description: Syslog output plugin supports TTL/SSL, for more details
-                      about the properties available and general configuration, please
-                      refer to the TLS/SSL section.
+                    description: Syslog output plugin supports TTL/SSL, for more details about the properties available and general configuration, please refer to the TLS/SSL section.
                     properties:
                       caFile:
                         description: Absolute path to CA certificate file
@@ -3912,9 +2865,7 @@ spec:
                         description: Absolute path to Certificate file
                         type: string
                       debug:
-                        description: 'Set TLS debug verbosity level. It accept the
-                          following values: 0 (No debug), 1 (Error), 2 (State change),
-                          3 (Informational) and 4 Verbose'
+                        description: 'Set TLS debug verbosity level. It accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose'
                         enum:
                         - 0
                         - 1
@@ -3930,26 +2881,19 @@ spec:
                         description: Optional password for tls.key_file file
                         properties:
                           valueFrom:
-                            description: ValueSource represents a source for the value
-                              of a secret.
+                            description: ValueSource represents a source for the value of a secret.
                             properties:
                               secretKeyRef:
-                                description: Selects a key of a secret in the pod's
-                                  namespace
+                                description: Selects a key of a secret in the pod's namespace
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.  Must
-                                      be a valid secret key.
+                                    description: The key of the secret to select from.  Must be a valid secret key.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the Secret or its
-                                      key must be defined
+                                    description: Specify whether the Secret or its key must be defined
                                     type: boolean
                                 required:
                                 - key
@@ -3968,8 +2912,7 @@ spec:
                 description: TCP defines TCP Output configuration.
                 properties:
                   format:
-                    description: Specify the data format to be printed. Supported
-                      formats are msgpack json, json_lines and json_stream.
+                    description: Specify the data format to be printed. Supported formats are msgpack json, json_lines and json_stream.
                     enum:
                     - msgpack
                     - json
@@ -3977,20 +2920,17 @@ spec:
                     - json_stream
                     type: string
                   host:
-                    description: Target host where Fluent-Bit or Fluentd are listening
-                      for Forward messages.
+                    description: Target host where Fluent-Bit or Fluentd are listening for Forward messages.
                     type: string
                   jsonDateFormat:
-                    description: 'Specify the format of the date. Supported formats
-                      are double, epoch and iso8601 (eg: 2018-05-30T09:39:52.000681Z)'
+                    description: 'Specify the format of the date. Supported formats are double, epoch and iso8601 (eg: 2018-05-30T09:39:52.000681Z)'
                     enum:
                     - double
                     - epoch
                     - iso8601
                     type: string
                   jsonDateKey:
-                    description: TSpecify the name of the time key in the output record.
-                      To disable the time key just set the value to false.
+                    description: TSpecify the name of the time key in the output record. To disable the time key just set the value to false.
                     type: string
                   port:
                     description: TCP Port of the target service.
@@ -3999,9 +2939,7 @@ spec:
                     minimum: 1
                     type: integer
                   tls:
-                    description: Fluent Bit provides integrated support for Transport
-                      Layer Security (TLS) and it predecessor Secure Sockets Layer
-                      (SSL) respectively.
+                    description: Fluent Bit provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.
                     properties:
                       caFile:
                         description: Absolute path to CA certificate file
@@ -4013,9 +2951,7 @@ spec:
                         description: Absolute path to Certificate file
                         type: string
                       debug:
-                        description: 'Set TLS debug verbosity level. It accept the
-                          following values: 0 (No debug), 1 (Error), 2 (State change),
-                          3 (Informational) and 4 Verbose'
+                        description: 'Set TLS debug verbosity level. It accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose'
                         enum:
                         - 0
                         - 1
@@ -4031,26 +2967,19 @@ spec:
                         description: Optional password for tls.key_file file
                         properties:
                           valueFrom:
-                            description: ValueSource represents a source for the value
-                              of a secret.
+                            description: ValueSource represents a source for the value of a secret.
                             properties:
                               secretKeyRef:
-                                description: Selects a key of a secret in the pod's
-                                  namespace
+                                description: Selects a key of a secret in the pod's namespace
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.  Must
-                                      be a valid secret key.
+                                    description: The key of the secret to select from.  Must be a valid secret key.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the Secret or its
-                                      key must be defined
+                                    description: Specify whether the Secret or its key must be defined
                                     type: boolean
                                 required:
                                 - key
@@ -4097,14 +3026,10 @@ spec:
         description: Parser is the Schema for the parsers API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -4112,21 +3037,14 @@ spec:
             description: ParserSpec defines the desired state of Parser
             properties:
               decoders:
-                description: 'Decoders are a built-in feature available through the
-                  Parsers file, each Parser definition can optionally set one or multiple
-                  decoders. There are two type of decoders type: Decode_Field and
-                  Decode_Field_As.'
+                description: 'Decoders are a built-in feature available through the Parsers file, each Parser definition can optionally set one or multiple decoders. There are two type of decoders type: Decode_Field and Decode_Field_As.'
                 items:
                   properties:
                     decodeField:
-                      description: If the content can be decoded in a structured message,
-                        append that structure message (keys and values) to the original
-                        log message.
+                      description: If the content can be decoded in a structured message, append that structure message (keys and values) to the original log message.
                       type: string
                     decodeFieldAs:
-                      description: Any content decoded (unstructured or structured)
-                        will be replaced in the same key/value, no extra keys are
-                        added.
+                      description: Any content decoded (unstructured or structured) will be replaced in the same key/value, no extra keys are added.
                       type: string
                   type: object
                 type: array


### PR DESCRIPTION
…arch Service

Signed-off-by: wanjunlei <wanjunlei@yunify.com>

- Add supports exporting logs to `Amazon ElasticSearch Service` and `Elastic's Elasticsearch Service`
- Add two features of es output, `Id_Key` and `Suppress_Type_Name`. These features are supported with Fluent bit 1.7+.