### PR TITLE
Expand fluetnbit permissions

### DIFF
--- a/charts/fluentbit-operator/templates/fluentbit-operator-clusterRole.yaml
+++ b/charts/fluentbit-operator/templates/fluentbit-operator-clusterRole.yaml
@@ -89,12 +89,12 @@ rules:
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:
-      - rolebindings
+      - clusterrolebindings
     verbs:
       - create
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:
-      - roles
+      - clusterroles
     verbs:
       - create

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -88,12 +88,12 @@ rules:
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
-  - rolebindings
+  - clusterrolebindings
   verbs:
   - create
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
-  - roles
+  - clusterroles
   verbs:
   - create

--- a/controllers/fluentbit_controller.go
+++ b/controllers/fluentbit_controller.go
@@ -44,8 +44,8 @@ type FluentBitReconciler struct {
 // +kubebuilder:rbac:groups=logging.kubesphere.io,resources=fluentbits;fluentbitconfigs;inputs;filters;outputs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=create
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=create
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=create
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=create
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get
 
 func (r *FluentBitReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/manifests/setup/fluentbit-operator-clusterRole.yaml
+++ b/manifests/setup/fluentbit-operator-clusterRole.yaml
@@ -89,12 +89,12 @@ rules:
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:
-      - rolebindings
+      - clusterrolebindings
     verbs:
       - create
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:
-      - roles
+      - clusterroles
     verbs:
       - create

--- a/pkg/operator/daemonset.go
+++ b/pkg/operator/daemonset.go
@@ -10,11 +10,10 @@ import (
 	"kubesphere.io/fluentbit-operator/api/fluentbitoperator/v1alpha2"
 )
 
-func MakeRBACObjects(fbName, fbNamespace string) (rbacv1.Role, corev1.ServiceAccount, rbacv1.RoleBinding) {
-	r := rbacv1.Role{
+func MakeRBACObjects(fbName, fbNamespace string) (rbacv1.ClusterRole, corev1.ServiceAccount, rbacv1.ClusterRoleBinding) {
+	cr := rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kubesphere:fluent-bit",
-			Namespace: fbNamespace,
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
@@ -32,10 +31,9 @@ func MakeRBACObjects(fbName, fbNamespace string) (rbacv1.Role, corev1.ServiceAcc
 		},
 	}
 
-	rb := rbacv1.RoleBinding{
+	crb := rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kubesphere:fluent-bit",
-			Namespace: fbNamespace,
 		},
 		Subjects: []rbacv1.Subject{
 			{
@@ -46,12 +44,12 @@ func MakeRBACObjects(fbName, fbNamespace string) (rbacv1.Role, corev1.ServiceAcc
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: rbacv1.GroupName,
-			Kind:     "Role",
+			Kind:     "ClusterRole",
 			Name:     "kubesphere:fluent-bit",
 		},
 	}
 
-	return r, sa, rb
+	return cr, sa, crb
 }
 
 func MakeDaemonSet(fb v1alpha2.FluentBit, logPath string) appsv1.DaemonSet {


### PR DESCRIPTION
If Fluentbit has role permissions, it can only access the namespace to which it belongs. Some plug-ins do not work properly, so Fluentbit should have ClusterRole permissions.
/cc @wanjunlei  @benjaminhuo 
Signed-off-by: wenchajun <dehaocheng@yunify.com>