### PR TITLE
Add priority class to FluentBit type

### DIFF
--- a/api/fluentbitoperator/v1alpha2/fluentbit_types.go
+++ b/api/fluentbitoperator/v1alpha2/fluentbit_types.go
@@ -52,6 +52,8 @@ type FluentBitSpec struct {
 	Secrets []string `json:"secrets,omitempty"`
 	// RuntimeClassName represents the container runtime configuration.
 	RuntimeClassName string `json:"runtimeClassName,omitempty"`
+	// RuntimeClassName represents the pod priority class.
+	PriorityClassName string `json:"priorityClassName,omitempty"`
 }
 
 // FluentBitStatus defines the observed state of FluentBit

--- a/api/fluentbitoperator/v1alpha2/fluentbit_types.go
+++ b/api/fluentbitoperator/v1alpha2/fluentbit_types.go
@@ -52,7 +52,7 @@ type FluentBitSpec struct {
 	Secrets []string `json:"secrets,omitempty"`
 	// RuntimeClassName represents the container runtime configuration.
 	RuntimeClassName string `json:"runtimeClassName,omitempty"`
-	// RuntimeClassName represents the pod priority class.
+	// PriorityClassName represents the pod's priority class.
 	PriorityClassName string `json:"priorityClassName,omitempty"`
 }
 

--- a/charts/fluentbit-operator/crds/logging.kubesphere.io_fluentbit.yaml
+++ b/charts/fluentbit-operator/crds/logging.kubesphere.io_fluentbit.yaml
@@ -1868,7 +1868,7 @@ spec:
                 description: RuntimeClassName represents the container runtime configuration.
                 type: string
               priorityClassName:
-                description: RuntimeClassName represents the pod priority class.
+                description: PriorityClassName represents the pod priority class.
                 type: string
               secrets:
                 description: The Secrets are mounted into /fluent-bit/secrets/<secret-name>.

--- a/charts/fluentbit-operator/crds/logging.kubesphere.io_fluentbit.yaml
+++ b/charts/fluentbit-operator/crds/logging.kubesphere.io_fluentbit.yaml
@@ -1867,6 +1867,9 @@ spec:
               runtimeClassName:
                 description: RuntimeClassName represents the container runtime configuration.
                 type: string
+              priorityClassName:
+                description: RuntimeClassName represents the pod priority class.
+                type: string
               secrets:
                 description: The Secrets are mounted into /fluent-bit/secrets/<secret-name>.
                 items:

--- a/config/crd/bases/logging.kubesphere.io_fluentbits.yaml
+++ b/config/crd/bases/logging.kubesphere.io_fluentbits.yaml
@@ -2290,7 +2290,7 @@ spec:
                     type: object
                 type: object
               priorityClassName:
-                description: RuntimeClassName represents the pod priority class.
+                description: PriorityClassName represents the pod's priority class.
                 type: string
               resources:
                 description: Compute Resources required by container.

--- a/config/crd/bases/logging.kubesphere.io_fluentbits.yaml
+++ b/config/crd/bases/logging.kubesphere.io_fluentbits.yaml
@@ -2289,6 +2289,9 @@ spec:
                     - volumePath
                     type: object
                 type: object
+              priorityClassName:
+                description: RuntimeClassName represents the pod priority class.
+                type: string
               resources:
                 description: Compute Resources required by container.
                 properties:

--- a/docs/crd.md
+++ b/docs/crd.md
@@ -159,6 +159,7 @@ FluentBitSpec defines the desired state of FluentBit
 | fluentBitConfigName | Fluentbitconfig object associated with this Fluentbit | string |
 | secrets | The Secrets are mounted into /fluent-bit/secrets/<secret-name>. | []string |
 | runtimeClassName | The runtimeClassName represents the container runtime configuration. | string |
+| runtimeClassName | The priorityClassName represents the pod's priority. | string |
 
 [Back to TOC](#table-of-contents)
 ## Input

--- a/manifests/setup/fluentbit-operator-crd.yaml
+++ b/manifests/setup/fluentbit-operator-crd.yaml
@@ -2995,6 +2995,9 @@ spec:
                     - volumePath
                     type: object
                 type: object
+              priorityClassName:
+                description: RuntimeClassName represents the pod priority class.
+                type: string
               resources:
                 description: Compute Resources required by container.
                 properties:

--- a/manifests/setup/fluentbit-operator-crd.yaml
+++ b/manifests/setup/fluentbit-operator-crd.yaml
@@ -2996,7 +2996,7 @@ spec:
                     type: object
                 type: object
               priorityClassName:
-                description: RuntimeClassName represents the pod priority class.
+                description: PriorityClassName represents the pod's priority class.
                 type: string
               resources:
                 description: Compute Resources required by container.

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -3000,6 +3000,9 @@ spec:
                     - volumePath
                     type: object
                 type: object
+              priorityClassName:
+                description: RuntimeClassName represents the pod priority class.
+                type: string
               resources:
                 description: Compute Resources required by container.
                 properties:

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -3001,7 +3001,7 @@ spec:
                     type: object
                 type: object
               priorityClassName:
-                description: RuntimeClassName represents the pod priority class.
+                description: PriorityClassName represents the pod's priority class.
                 type: string
               resources:
                 description: Compute Resources required by container.

--- a/pkg/operator/daemonset.go
+++ b/pkg/operator/daemonset.go
@@ -210,6 +210,10 @@ func MakeDaemonSet(fb v1alpha2.FluentBit, logPath string) appsv1.DaemonSet {
 		ds.Spec.Template.Spec.RuntimeClassName = &fb.Spec.RuntimeClassName
 	}
 
+	if fb.Spec.PriorityClassName != "" {
+		ds.Spec.Template.Spec.PriorityClassName = fb.Spec.PriorityClassName
+	}
+
 	// Mount Position DB
 	if fb.Spec.PositionDB != (corev1.VolumeSource{}) {
 		ds.Spec.Template.Spec.Volumes = append(ds.Spec.Template.Spec.Volumes, corev1.Volume{


### PR DESCRIPTION
Adds `PriorityClassName` property to `FluentBit` type which translates to `PriorityClassName` within the fluent bit daemonset.