### PR TITLE
Add support for RetryLimit in outputs

### DIFF
--- a/api/fluentbitoperator/v1alpha2/output_types.go
+++ b/api/fluentbitoperator/v1alpha2/output_types.go
@@ -40,6 +40,9 @@ type OutputSpec struct {
 	// A user friendly alias name for this output plugin.
 	// Used in metrics for distinction of each configured output.
 	Alias string `json:"alias,omitempty"`
+	// RetryLimit represents configuration for the scheduler which can be set independently on each output section.
+	// This option allows to disable retries or impose a limit to try N times and then discard the data after reaching that limit.
+	RetryLimit string `json:"retry_limit,omitempty"`
 	// Elasticsearch defines Elasticsearch Output configuration.
 	Elasticsearch *output.Elasticsearch `json:"es,omitempty"`
 	// File defines File Output configuration.
@@ -111,6 +114,9 @@ func (list OutputList) Load(sl plugins.SecretLoader) (string, error) {
 			}
 			if item.Spec.Alias != "" {
 				buf.WriteString(fmt.Sprintf("    Alias    %s\n", item.Spec.Alias))
+			}
+			if item.Spec.RetryLimit != "" {
+				buf.WriteString(fmt.Sprintf("    Retry_Limit    %s\n", item.Spec.RetryLimit))
 			}
 			kvs, err := p.Params(sl)
 			if err != nil {

--- a/config/crd/bases/logging.kubesphere.io_outputs.yaml
+++ b/config/crd/bases/logging.kubesphere.io_outputs.yaml
@@ -944,6 +944,12 @@ spec:
               "null":
                 description: Null defines Null Output configuration.
                 type: object
+              retry_limit:
+                description: RetryLimit represents configuration for the scheduler
+                  which can be set independently on each output section. This option
+                  allows to disable retries or impose a limit to try N times and then
+                  discard the data after reaching that limit.
+                type: string
               stdout:
                 description: Stdout defines Stdout Output configuration.
                 properties:

--- a/manifests/setup/fluentbit-operator-crd.yaml
+++ b/manifests/setup/fluentbit-operator-crd.yaml
@@ -4303,6 +4303,12 @@ spec:
               "null":
                 description: Null defines Null Output configuration.
                 type: object
+              retry_limit:
+                description: RetryLimit represents configuration for the scheduler
+                  which can be set independently on each output section. This option
+                  allows to disable retries or impose a limit to try N times and then
+                  discard the data after reaching that limit.
+                type: string
               stdout:
                 description: Stdout defines Stdout Output configuration.
                 properties:

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -4308,6 +4308,12 @@ spec:
               "null":
                 description: Null defines Null Output configuration.
                 type: object
+              retry_limit:
+                description: RetryLimit represents configuration for the scheduler
+                  which can be set independently on each output section. This option
+                  allows to disable retries or impose a limit to try N times and then
+                  discard the data after reaching that limit.
+                type: string
               stdout:
                 description: Stdout defines Stdout Output configuration.
                 properties:


### PR DESCRIPTION
Adds support for [Retry_Limit](https://docs.fluentbit.io/manual/administration/scheduling-and-retries#configuring-retries) output plugin configuration property.