### PR TITLE
Fix the incorrect keys of the es output plugin

### DIFF
--- a/api/fluentbitoperator/v1alpha2/plugins/output/elasticsearch_types.go
+++ b/api/fluentbitoperator/v1alpha2/plugins/output/elasticsearch_types.go
@@ -153,10 +153,10 @@ func (es *Elasticsearch) Params(sl plugins.SecretLoader) (*params.KVs, error) {
 		kvs.Insert("HTTP_Passwd", pwd)
 	}
 	if es.Index != "" {
-		kvs.Insert("Host", es.Index)
+		kvs.Insert("Index", es.Index)
 	}
 	if es.Type != "" {
-		kvs.Insert("Host", es.Type)
+		kvs.Insert("Type", es.Type)
 	}
 	if es.LogstashFormat != nil {
 		kvs.Insert("Logstash_Format", fmt.Sprint(*es.LogstashFormat))


### PR DESCRIPTION
Signed-off-by: dkeven <keven@kubesphere.io>

When generating params from the `Elasticsearch` type, in:

https://github.com/fluent/fluentbit-operator/blob/4b96fcc0a7e19a5bb89f7051982d7bcee538b2a2/api/fluentbitoperator/v1alpha2/plugins/output/elasticsearch_types.go#L155-L159

,the config keys of the `Type` and `Index` fields are incorrectly set to `Host` if they are not empty, resulting in an overwriting of the true `Host` config, like in this issue: https://github.com/kubesphere/kubesphere/issues/4395