### PR TITLE
tail new multiline support(fluentbit must be later than V1.8)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -35,6 +35,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Go mod
+        run: |
+          export PATH=$PATH:$(go env GOPATH)/bin
+          go mod download
+
       - name: Install kubebuilder-3.1.0
         run: |
           curl -L -o kubebuilder "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v3.1.0/kubebuilder_linux_amd64"

--- a/api/fluentbitoperator/v1alpha2/plugins/input/tail_types.go
+++ b/api/fluentbitoperator/v1alpha2/plugins/input/tail_types.go
@@ -87,6 +87,9 @@ type Tail struct {
 	DockerModeFlushSeconds *int64 `json:"dockerModeFlushSeconds,omitempty"`
 	// DisableInotifyWatcher will disable inotify and use the file stat watcher instead.
 	DisableInotifyWatcher *bool `json:"disableInotifyWatcher,omitempty"`
+	// This will help to reassembly multiline messages originally split by Docker or CRI
+	//Specify one or Multiline Parser definition to apply to the content.
+	MultilineParser string `json:"multilineParser,omitempty"`
 }
 
 func (_ *Tail) Name() string {
@@ -166,6 +169,9 @@ func (t *Tail) Params(_ plugins.SecretLoader) (*params.KVs, error) {
 	}
 	if t.DisableInotifyWatcher != nil {
 		kvs.Insert("Inotify_Watcher", fmt.Sprint(!*t.DisableInotifyWatcher))
+	}
+	if t.MultilineParser != "" {
+		kvs.Insert("multiline.parser", t.MultilineParser)
 	}
 	return kvs, nil
 }

--- a/conf/parsers.conf
+++ b/conf/parsers.conf
@@ -95,6 +95,24 @@
     Time_Keep   On
     Time_Key time
 
+[MULTILINE_PARSER]
+    name          multiline-regex-test
+    type          regex
+    flush_timeout 1000
+    #
+    # Regex rules for multiline parsing
+    # ---------------------------------
+    #
+    # configuration hints:
+    #
+    #  - first state always has the name: start_state
+    #  - every field in the rule must be inside double quotes
+    #
+    # rules |   state name  | regex pattern                  | next state
+    # ------|---------------|--------------------------------------------
+    rule      "start_state"   "/(Dec \d+ \d+\:\d+\:\d+)(.*)/"  "cont"
+    rule      "cont"          "/^\s+at.*/"                     "cont"
+
 [PARSER]
     # https://rubular.com/r/3fVxCrE5iFiZim
     Name    envoy

--- a/config/crd/bases/logging.kubesphere.io_inputs.yaml
+++ b/config/crd/bases/logging.kubesphere.io_inputs.yaml
@@ -212,6 +212,11 @@ spec:
                       messages
                     format: int64
                     type: integer
+                  multilineParser:
+                    description: This will help to reassembly multiline messages originally
+                      split by Docker or CRI Specify one or Multiline Parser definition
+                      to apply to the content.
+                    type: string
                   parser:
                     description: Specify the name of a parser to interpret the entry
                       as a structured message.

--- a/manifests/setup/fluentbit-operator-crd.yaml
+++ b/manifests/setup/fluentbit-operator-crd.yaml
@@ -3315,6 +3315,11 @@ spec:
                       messages
                     format: int64
                     type: integer
+                  multilineParser:
+                    description: This will help to reassembly multiline messages originally
+                      split by Docker or CRI Specify one or Multiline Parser definition
+                      to apply to the content.
+                    type: string
                   parser:
                     description: Specify the name of a parser to interpret the entry
                       as a structured message.

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -3320,6 +3320,11 @@ spec:
                       messages
                     format: int64
                     type: integer
+                  multilineParser:
+                    description: This will help to reassembly multiline messages originally
+                      split by Docker or CRI Specify one or Multiline Parser definition
+                      to apply to the content.
+                    type: string
                   parser:
                     description: Specify the name of a parser to interpret the entry
                       as a structured message.


### PR DESCRIPTION
https://docs.fluentbit.io/manual/pipeline/inputs/tail#multiline-and-containers-v1.8
If you are running Fluent Bit to process logs coming from containers like Docker or CRI, you can use the new built-in modes for such purposes. This will help to reassembly multiline messages originally split by Docker or CRI:
```
[INPUT]
    name              tail
    path              /var/log/containers/*.log
    multiline.parser  docker, cri
```
Signed-off-by: chengdehao <dehaocheng@yunify.com>