### PR TITLE
Add build and push image CI

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -1,0 +1,101 @@
+name: WorkFlow for Building image
+
+on:
+  push:
+    branches:
+      - 'master'
+    tags:
+      - 'v*'
+    paths:
+      - ".github/workflows/**"
+      - "apis/**"
+      - "charts/**"
+      - "cmd/**"
+      - "controllers/**"
+      - "hack/**"
+      - "manifests/setup/setup.yaml"
+      - "pkg/**"
+      - "Makefile"
+
+env:
+  REGISTRY_REPO: 'kubesphere'
+
+jobs:
+  operator-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    name: Build Image for Fluent Operator
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.x
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build and Push Image for Fluent Operator
+        run: |
+          tag=$(cat VERSION | tr -d " \t\n\r")
+          make build-op -e FO_IMG=${{ env.REGISTRY_REPO }}/fluent-operator:$tag
+
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    name: Build Image for Fluent Bit and Fluentd
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.x
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Setting environment Variables
+        run: |
+          tag=$(cat VERSION | tr -d " \t\n\r")
+          FB_IMG=${{ env.REGISTRY_REPO }}/fluent-bit:$tag
+          FD_IMG=${{ env.REGISTRY_REPO }}/fluentd:$tag
+          echo "tag=$FB_IMG" >> $GITHUB_ENV 
+          echo "tag=$FD_IMG" >> $GITHUB_ENV 
+
+      - name: Build and Push Image for Fluent Bit
+        run: |
+          make build-fb-amd64 -e $FB_IMG
+          docker push $FB_IMG
+
+      - name: Build and Push Image for Fluentd
+        run: |
+          make build-fd-amd64 -e $FD_IMG
+          docker push $FD_IMG

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ FB_IMG ?= kubesphere/fluent-bit:v1.8.3
 FD_IMG ?= kubesphere/fluentd:v1.14.4
 FO_IMG ?= kubesphere/fluent-operator:$(VERSION)
 
-AMD64 ?= -amd64
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 
@@ -102,15 +101,15 @@ build-amd64: build-op-amd64 build-fb-amd64 build-fd-amd64
 
 # Build amd64 Fluent Operator container image
 build-op-amd64:
-	docker build -f cmd/fluent-manager/Dockerfile . -t ${FO_IMG}${AMD64}
+	docker build -f cmd/fluent-manager/Dockerfile . -t ${FO_IMG}
 
 # Build amd64 Fluent Bit container image
 build-fb-amd64:
-	docker build -f cmd/fluent-watcher/fluentbit/Dockerfile . -t ${FB_IMG}${AMD64}
+	docker build -f cmd/fluent-watcher/fluentbit/Dockerfile . -t ${FB_IMG}
 
 # Build amd64 Fluent Bit container image
 build-fd-amd64:
-	docker build -f cmd/fluent-watcher/fluentd/Dockerfile.complete . -t ${FD_IMG}${AMD64}
+	docker build -f cmd/fluent-watcher/fluentd/Dockerfile.complete . -t ${FD_IMG}
 
 # Push the amd64 docker image
 push-amd64:


### PR DESCRIPTION
Signed-off-by: zhu733756 <zhu733756@kubesphere.io>

Push images to the org like kubesphere after adding accounts with permissions. Suppose the tag is `latest`.
- `kubepshere/fluentbit-operator:latest` with buildx(and64/arm64)
- `kubesphere/fluentbit:latest` with amd64
- `kubesphere/fluentd:latest` with amd64

Each pr after merged will push a new image.